### PR TITLE
WAR-26: Add automated NPM publish

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -1,0 +1,29 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Package
+        run: npm run build:comet-uswds
+
+      - name: Publish Package
+        run: npm run publish:comet-uswds
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "build:storybook": "storybook build",
     "build:comet-uswds": "cd packages/comet-uswds && rollup -c",
     "build:comet-data-viz": "cd packages/comet-data-viz && rollup -c",
-    "build:comet-extras": "cd packages/comet-extras && rollup -c"
+    "build:comet-extras": "cd packages/comet-extras && rollup -c",
+    "publish:comet-uswds": "cd packages/comet-uswds && npm publish --access public --provenance",
+    "publish:comet-data-viz": "cd packages/comet-data-viz && npm publish --access public --provenance",
+    "publish:comet-extras": "cd packages/comet-extras && npm publish --access public --provenance"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",


### PR DESCRIPTION
Updates to automate publishing to NPM upon publishing a new release.

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added publish package github action
- Added scripts to package.json for publishing

## Related Issue

N/A

## Motivation and Context

Establish a consistent, scalable approach to publishing npm packages

## How Has This Been Tested?

Scripts ran locally

## Screenshots (if appropriate):
N/A