### PR TITLE
CSG-818: Add Advanced Datatable Component to Comet Extras

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6698,6 +6698,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.9.3.tgz",
+      "integrity": "sha512-Ng9rdm3JPoSCi6cVZvANsYnF+UoGVRxflMb270tVj0+LjeT/ZtZ9ckxF6oLPLcKesza6VKBqtdF9mQ+vaz24Aw==",
+      "dependencies": {
+        "@tanstack/table-core": "8.9.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.9.3.tgz",
+      "integrity": "sha512-NpHZBoHTfqyJk0m/s/+CSuAiwtebhYK90mDuf5eylTvgViNOujiaOaxNDxJkQQAsVvHWZftUGAx1EfO1rkKtLg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
@@ -24041,6 +24072,7 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tanstack/react-table": "8.9.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/packages/comet-extras/package.json
+++ b/packages/comet-extras/package.json
@@ -17,6 +17,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/comet-extras/src/components/data-table/data-table.stories.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import DataTable, { DataTableProps } from './data-table';
+import { createColumnHelper } from '@tanstack/react-table';
+
+const meta: Meta<typeof DataTable> = {
+  title: 'Extras/Data Table',
+  component: DataTable,
+};
+export default meta;
+
+const Template: StoryFn<typeof DataTable> = (args: DataTableProps) => (
+  <DataTable {...args}></DataTable>
+);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type Person = {
+  firstName: string;
+  lastName: string;
+};
+
+const data: Person[] = [
+  {
+    firstName: 'tanner',
+    lastName: 'linsley',
+  },
+  {
+    firstName: 'tandy',
+    lastName: 'miller',
+  },
+  {
+    firstName: 'joe',
+    lastName: 'dirte',
+  },
+];
+
+const columnHelper = createColumnHelper<Person>();
+
+const cols = [
+  columnHelper.accessor('firstName', {
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor((row) => row.lastName, {
+    id: 'lastName',
+    cell: (info) => <i>{info.getValue()}</i>,
+    header: () => <span>Last Name</span>,
+  }),
+];
+
+export const Default = Template.bind({});
+Default.args = {
+  id: 'table-1',
+  columns: cols,
+  data,
+};

--- a/packages/comet-extras/src/components/data-table/data-table.stories.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.stories.tsx
@@ -13,24 +13,42 @@ const Template: StoryFn<typeof DataTable> = (args: DataTableProps) => (
   <DataTable {...args}></DataTable>
 );
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type Person = {
+interface Person {
   firstName: string;
   lastName: string;
-};
+  middleName?: string;
+  age: number;
+  gender: 'M' | 'F' | 'NA';
+}
 
 const data: Person[] = [
   {
-    firstName: 'tanner',
-    lastName: 'linsley',
+    firstName: 'John',
+    lastName: 'Doe',
+    middleName: 'L',
+    age: 30,
+    gender: 'M',
   },
   {
-    firstName: 'tandy',
-    lastName: 'miller',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    middleName: 'M',
+    age: 29,
+    gender: 'F',
   },
   {
-    firstName: 'joe',
-    lastName: 'dirte',
+    firstName: 'Bob',
+    lastName: 'Ross',
+    middleName: '',
+    age: 100,
+    gender: 'M',
+  },
+  {
+    firstName: 'Elon',
+    lastName: 'Musk',
+    middleName: 'R',
+    age: 2032,
+    gender: 'M',
   },
 ];
 
@@ -39,11 +57,23 @@ const columnHelper = createColumnHelper<Person>();
 const cols = [
   columnHelper.accessor('firstName', {
     cell: (info) => info.getValue(),
+    header: () => 'First Name',
   }),
-  columnHelper.accessor((row) => row.lastName, {
-    id: 'lastName',
-    cell: (info) => <i>{info.getValue()}</i>,
-    header: () => <span>Last Name</span>,
+  columnHelper.accessor('lastName', {
+    cell: (info) => info.getValue(),
+    header: () => 'Last Name',
+  }),
+  columnHelper.accessor('middleName', {
+    cell: (info) => info.getValue(),
+    header: () => 'Middle Name',
+  }),
+  columnHelper.accessor('age', {
+    cell: (info) => info.getValue(),
+    header: () => 'Age',
+  }),
+  columnHelper.accessor('gender', {
+    cell: (info) => info.getValue(),
+    header: () => 'Gender',
   }),
 ];
 
@@ -52,4 +82,6 @@ Default.args = {
   id: 'table-1',
   columns: cols,
   data,
+  striped: false,
+  className: 'width-full',
 };

--- a/packages/comet-extras/src/components/data-table/data-table.stories.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.stories.tsx
@@ -53,6 +53,41 @@ const data: Person[] = [
     age: 2032,
     gender: 'M',
   },
+  {
+    firstName: 'Bill',
+    lastName: 'Gates',
+    middleName: '',
+    age: 75,
+    gender: 'M',
+  },
+  {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    middleName: '',
+    age: 36,
+    gender: 'F',
+  },
+  {
+    firstName: 'Alan',
+    lastName: 'Turing',
+    middleName: '',
+    age: 41,
+    gender: 'M',
+  },
+  {
+    firstName: 'Dwayne',
+    lastName: 'Johnson',
+    middleName: '',
+    age: 51,
+    gender: 'M',
+  },
+  {
+    firstName: 'Kirk',
+    lastName: 'Hammett',
+    middleName: '',
+    age: 60,
+    gender: 'M',
+  },
 ];
 
 const columnHelper = createColumnHelper<Person>();
@@ -89,5 +124,8 @@ Default.args = {
   sortable: true,
   sortDir: 'asc',
   sortCol: 'lastName',
+  pageable: true,
+  pageIndex: 0,
+  pageSize: 3,
   className: 'width-full',
 };

--- a/packages/comet-extras/src/components/data-table/data-table.stories.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.stories.tsx
@@ -6,6 +6,9 @@ import { createColumnHelper } from '@tanstack/react-table';
 const meta: Meta<typeof DataTable> = {
   title: 'Extras/Data Table',
   component: DataTable,
+  argTypes: {
+    sortDir: { control: 'select' },
+  },
 };
 export default meta;
 
@@ -83,5 +86,8 @@ Default.args = {
   columns: cols,
   data,
   striped: false,
+  sortable: true,
+  sortDir: 'asc',
+  sortCol: 'lastName',
   className: 'width-full',
 };

--- a/packages/comet-extras/src/components/data-table/data-table.style.css
+++ b/packages/comet-extras/src/components/data-table/data-table.style.css
@@ -1,0 +1,21 @@
+table {
+  border: 1px solid lightgray;
+}
+
+tbody {
+  border-bottom: 1px solid lightgray;
+}
+
+th {
+  border-bottom: 1px solid lightgray;
+  border-right: 1px solid lightgray;
+  padding: 2px 4px;
+}
+
+tfoot {
+  color: gray;
+}
+
+tfoot th {
+  font-weight: normal;
+}

--- a/packages/comet-extras/src/components/data-table/data-table.style.css
+++ b/packages/comet-extras/src/components/data-table/data-table.style.css
@@ -67,6 +67,10 @@ table.data-table th.sort-desc::before {
   border-radius: 6px;
 }
 
+.table-paging .table-paging-btn:not(:disabled) {
+  cursor: pointer;
+}
+
 .table-paging .table-paging-btn-active {
   border: 1px solid #ededed;
 }

--- a/packages/comet-extras/src/components/data-table/data-table.style.css
+++ b/packages/comet-extras/src/components/data-table/data-table.style.css
@@ -1,21 +1,54 @@
-table {
-  border: 1px solid lightgray;
+table.data-table {
+  border-spacing: 0;
+  border: 1px solid #ededed;
 }
 
-tbody {
-  border-bottom: 1px solid lightgray;
+table.data-table tr:last-child td {
+  border-bottom: 0;
 }
 
-th {
-  border-bottom: 1px solid lightgray;
-  border-right: 1px solid lightgray;
-  padding: 2px 4px;
+table.data-table th {
+  text-align: left;
+  background-color: #fafafa;
+  font-weight: 500;
 }
 
-tfoot {
-  color: gray;
+table.data-table th,
+table.data-table td {
+  margin: 0;
+  padding: 16px;
+  border-bottom: 1px solid #ededed;
+  position: relative;
 }
 
-tfoot th {
-  font-weight: normal;
+table.data-table th:last-child,
+table.data-table td:last-child {
+  border-right: 0;
+}
+
+table.data-table tr:hover {
+  background-color: #fafafa;
+}
+
+table.data-table.striped tr:nth-child(even) {
+  background-color: #fafafa;
+}
+
+table.data-table th::before {
+  position: absolute;
+  right: 15px;
+  top: 16px;
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+}
+
+table.data-table th.sort-asc::before {
+  border-bottom: 5px solid #22543d;
+}
+
+table.data-table th.sort-desc::before {
+  border-top: 5px solid #22543d;
 }

--- a/packages/comet-extras/src/components/data-table/data-table.style.css
+++ b/packages/comet-extras/src/components/data-table/data-table.style.css
@@ -52,3 +52,21 @@ table.data-table th.sort-asc::before {
 table.data-table th.sort-desc::before {
   border-top: 5px solid #22543d;
 }
+
+.table-paging {
+  padding-top: 16px;
+}
+
+.table-paging .table-paging-btn,
+.table-paging .table-paging-prev,
+.table-paging .table-paging-next {
+  border: transparent;
+  background-color: unset;
+  margin: 2px;
+  padding: 8px 14px;
+  border-radius: 6px;
+}
+
+.table-paging .table-paging-btn-active {
+  border: 1px solid #ededed;
+}

--- a/packages/comet-extras/src/components/data-table/data-table.test.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.test.tsx
@@ -1,11 +1,188 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import DataTable from './data-table';
+import { createColumnHelper } from '@tanstack/react-table';
+
+export interface Person {
+  firstName: string;
+  lastName: string;
+}
 
 describe('DataTable', () => {
+  const basicData: Person[] = [
+    {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+    {
+      firstName: 'Jane',
+      lastName: 'Doe',
+    },
+    {
+      firstName: 'Bob',
+      lastName: 'Ross',
+    },
+    {
+      firstName: 'Elon',
+      lastName: 'Musk',
+    },
+    {
+      firstName: 'Bill',
+      lastName: 'Gates',
+    },
+    {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    },
+    {
+      firstName: 'Alan',
+      lastName: 'Turing',
+    },
+    {
+      firstName: 'Dwayne',
+      lastName: 'Johnson',
+    },
+    {
+      firstName: 'Kirk',
+      lastName: 'Hammett',
+    },
+  ];
+
+  const columnHelper = createColumnHelper<Person>();
+
+  const cols = [
+    columnHelper.accessor('firstName', {
+      cell: (info) => info.getValue(),
+      header: () => 'First Name',
+    }),
+    columnHelper.accessor('lastName', {
+      cell: (info) => info.getValue(),
+      header: () => 'Last Name',
+    }),
+  ];
+
   test('should render with no accessibility violations', async () => {
     const { container } = render(<DataTable id="table-1" columns={[]} data={[]}></DataTable>);
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('should render a basic data table successfully', () => {
+    const { baseElement } = render(
+      <DataTable id="table-1" columns={cols} data={basicData}></DataTable>,
+    );
+
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+  });
+
+  test('should render a striped table successfully', () => {
+    const { baseElement } = render(
+      <DataTable id="table-1" columns={cols} data={basicData} striped></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1.striped');
+    expect(table).toBeTruthy();
+  });
+
+  test('should render a default sortable table successfully', () => {
+    const { baseElement } = render(
+      <DataTable id="table-1" columns={cols} data={basicData} sortable></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+    const sortableBtns = baseElement.querySelectorAll('.cursor-pointer');
+    expect(sortableBtns).toHaveLength(2);
+  });
+
+  test('should render a non-default sortable table successfully', () => {
+    const { baseElement } = render(
+      <DataTable
+        id="table-1"
+        columns={cols}
+        data={basicData}
+        sortable
+        sortCol="lastName"
+        sortDir="asc"
+      ></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+    const sortableBtns = baseElement.querySelectorAll('.cursor-pointer');
+    expect(sortableBtns).toHaveLength(2);
+  });
+
+  test('should render a default pageable table successfully', () => {
+    const { baseElement } = render(
+      <DataTable id="table-1" columns={cols} data={basicData} pageable></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+    const pagingSection = baseElement.querySelector('.table-paging');
+    expect(pagingSection).toBeTruthy();
+  });
+
+  test('should render a non-default pageable table successfully', () => {
+    const { baseElement } = render(
+      <DataTable
+        id="table-1"
+        columns={cols}
+        data={basicData}
+        pageable
+        pageIndex={1}
+        pageSize={3}
+      ></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+    const pagingSection = baseElement.querySelector('.table-paging');
+    expect(pagingSection).toBeTruthy();
+  });
+
+  test('should page through table ', async () => {
+    const { baseElement } = render(
+      <DataTable
+        id="table-1"
+        columns={cols}
+        data={basicData}
+        pageable
+        pageIndex={0}
+        pageSize={3}
+      ></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+
+    const pagingSection = baseElement.querySelector('.table-paging');
+    if (pagingSection) {
+      const nextBtn = pagingSection.querySelector('#table-paging-next-btn') as HTMLButtonElement;
+      const prevBtn = pagingSection.querySelector('#table-paging-prev-btn') as HTMLButtonElement;
+      const pageBtn = pagingSection.querySelector('#table-paging-btn') as HTMLButtonElement;
+      if (nextBtn) {
+        expect(nextBtn).toBeTruthy();
+        await act(async () => {
+          nextBtn.click();
+        });
+      }
+      if (prevBtn) {
+        expect(prevBtn).toBeTruthy();
+        await act(async () => {
+          prevBtn.click();
+        });
+      }
+      if (pageBtn) {
+        expect(pageBtn).toBeTruthy();
+        await act(async () => {
+          pageBtn.click();
+        });
+      }
+    }
+  });
+
+  test('should render a table with custom class successfully', () => {
+    const { baseElement } = render(
+      <DataTable id="table-1" columns={cols} data={basicData} className="width-full"></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1.width-full');
+    expect(table).toBeTruthy();
   });
 });

--- a/packages/comet-extras/src/components/data-table/data-table.test.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.test.tsx
@@ -138,6 +138,37 @@ describe('DataTable', () => {
     expect(pagingSection).toBeTruthy();
   });
 
+  test('should render a non-default pageable table with large number of pages successfully', () => {
+    const { baseElement } = render(
+      <DataTable id="table-1" columns={cols} data={basicData} pageable pageSize={1}></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+    const pagingSection = baseElement.querySelector('.table-paging');
+    expect(pagingSection).toBeTruthy();
+    const pagingBtns = pagingSection?.querySelectorAll('.table-paging-btn');
+    expect(pagingBtns).toHaveLength(7);
+  });
+
+  test('should render a non-default pageable table with large number of pages and current page successfully', () => {
+    const { baseElement } = render(
+      <DataTable
+        id="table-1"
+        columns={cols}
+        data={basicData}
+        pageable
+        pageIndex={5}
+        pageSize={1}
+      ></DataTable>,
+    );
+    const table = baseElement.querySelector('#table-1');
+    expect(table).toBeTruthy();
+    const pagingSection = baseElement.querySelector('.table-paging');
+    expect(pagingSection).toBeTruthy();
+    const pagingBtns = pagingSection?.querySelectorAll('.table-paging-btn');
+    expect(pagingBtns).toHaveLength(7);
+  });
+
   test('should page through table ', async () => {
     const { baseElement } = render(
       <DataTable

--- a/packages/comet-extras/src/components/data-table/data-table.test.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import DataTable from './data-table';
+
+describe('DataTable', () => {
+  test('should render with no accessibility violations', async () => {
+    const { container } = render(<DataTable id="table-1" columns={[]} data={[]}></DataTable>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -92,6 +92,24 @@ export const DataTable = ({
     getPaginationRowModel: getPaginationRowModel(),
   });
 
+  const getPageButtonArray = (): number[] => {
+    const totalPages = table.getPageCount();
+    const array = Array.from({ length: totalPages }, (_, index) => index++);
+    // Display up to 5 paging buttons at a time
+    if (totalPages <= 5) {
+      return array.slice(0, totalPages);
+    } else {
+      const currentPage = paging.pageIndex;
+      if (currentPage < 4) {
+        return array.slice(0, 5);
+      } else {
+        const firstPage = currentPage - 3;
+        const lastPage = firstPage + 5;
+        return array.slice(firstPage, lastPage);
+      }
+    }
+  };
+
   return (
     <>
       <table id={id} className={classNames('data-table', { striped }, className)}>
@@ -141,11 +159,11 @@ export const DataTable = ({
           >
             {'<'}
           </button>
-          {Array.from({ length: table.getPageCount() }).map((row, index) => {
+          {getPageButtonArray().map((index) => {
             return (
               <button
                 id="table-paging-btn"
-                key={`paging-btn-${row}-${index}`}
+                key={`paging-btn-${index}`}
                 className={`table-paging-btn table-paging-btn ${
                   index === paging.pageIndex ? 'table-paging-btn-active' : ''
                 }`}

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -120,22 +120,19 @@ export const DataTable = ({
           ))}
         </thead>
         <tbody>
-          {table
-            .getRowModel()
-            .rows.slice(0, 10)
-            .map((row) => {
-              return (
-                <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => {
-                    return (
-                      <td key={cell.id}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       {pageable ? (

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -100,20 +100,18 @@ export const DataTable = ({
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <th key={header.id}>
-                  {header.isPlaceholder ? null : (
-                    <div
-                      {...{
-                        className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
-                        onClick: header.column.getToggleSortingHandler(),
-                      }}
-                    >
-                      {flexRender(header.column.columnDef.header, header.getContext())}
-                      {{
-                        asc: '  ↑',
-                        desc: '  ↓',
-                      }[header.column.getIsSorted() as string] ?? null}
-                    </div>
-                  )}
+                  <div
+                    {...{
+                      className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                      onClick: header.column.getToggleSortingHandler(),
+                    }}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {{
+                      asc: '  ↑',
+                      desc: '  ↓',
+                    }[header.column.getIsSorted() as string] ?? null}
+                  </div>
                 </th>
               ))}
             </tr>

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import './data-table.style.css';
+
+export interface DataTableProps<T = any> {
+  /**
+   * The unique identifier for this component
+   */
+  id: string;
+  /**
+   * The table column definitions
+   */
+  columns: T[];
+  /**
+   * The data to display in the table rows
+   */
+  data: T[];
+}
+/**
+ * A Data Table shows information in columns and rows, with advanced functionality.
+ */
+export const DataTable = ({ id, columns, data }: DataTableProps): React.ReactElement => {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <table id={id}>
+      <thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <th key={header.id}>
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default DataTable;

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import classNames from 'classnames';
 import './data-table.style.css';
 
 export interface DataTableProps<T = any> {
@@ -15,11 +16,22 @@ export interface DataTableProps<T = any> {
    * The data to display in the table rows
    */
   data: T[];
+  striped: boolean;
+  /**
+   * Additional class names for the table
+   */
+  className?: string;
 }
 /**
  * A Data Table shows information in columns and rows, with advanced functionality.
  */
-export const DataTable = ({ id, columns, data }: DataTableProps): React.ReactElement => {
+export const DataTable = ({
+  id,
+  columns,
+  data,
+  striped,
+  className,
+}: DataTableProps): React.ReactElement => {
   const table = useReactTable({
     data,
     columns,
@@ -27,7 +39,7 @@ export const DataTable = ({ id, columns, data }: DataTableProps): React.ReactEle
   });
 
   return (
-    <table id={id}>
+    <table id={id} className={classNames('data-table', { striped }, className)}>
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
-  ColumnSort,
   SortingState,
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
+  getPaginationRowModel,
+  PaginationState,
 } from '@tanstack/react-table';
 import classNames from 'classnames';
 import './data-table.style.css';
@@ -40,6 +41,18 @@ export interface DataTableProps<T = any> {
    */
   sortDir?: 'asc' | 'desc';
   /**
+   * A boolean indicating if the table is pageable or not
+   */
+  pageable?: boolean;
+  /**
+   * The index of the page to display as default
+   */
+  pageIndex?: number;
+  /**
+   * The number of items to display per page
+   */
+  pageSize?: number;
+  /**
    * Additional class names for the table
    */
   className?: string;
@@ -55,68 +68,110 @@ export const DataTable = ({
   sortable = false,
   sortCol,
   sortDir,
+  pageable = false,
+  pageIndex = 0,
+  pageSize = 10,
   className,
 }: DataTableProps): React.ReactElement => {
   const [sorting, setSorting] = React.useState<SortingState>(
     sortable ? [{ id: sortCol ?? columns[0], desc: sortDir === 'desc' }] : [],
   );
+  const [paging, setPaging] = React.useState<PaginationState>({ pageIndex, pageSize });
   const table = useReactTable({
     data,
     columns,
     state: {
       sorting,
+      pagination: paging,
     },
     enableSorting: sortable,
     onSortingChange: setSorting,
+    onPaginationChange: setPaging,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
   });
 
   return (
-    <table id={id} className={classNames('data-table', { striped }, className)}>
-      <thead>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th key={header.id}>
-                {header.isPlaceholder ? null : (
-                  <div
-                    {...{
-                      className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
-                      onClick: header.column.getToggleSortingHandler(),
-                    }}
-                  >
-                    {flexRender(header.column.columnDef.header, header.getContext())}
-                    {{
-                      asc: '  ↑',
-                      desc: '  ↓',
-                    }[header.column.getIsSorted() as string] ?? null}
-                  </div>
-                )}
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody>
-        {table
-          .getRowModel()
-          .rows.slice(0, 10)
-          .map((row) => {
+    <>
+      <table id={id} className={classNames('data-table', { striped }, className)}>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id}>
+                  {header.isPlaceholder ? null : (
+                    <div
+                      {...{
+                        className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                        onClick: header.column.getToggleSortingHandler(),
+                      }}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {{
+                        asc: '  ↑',
+                        desc: '  ↓',
+                      }[header.column.getIsSorted() as string] ?? null}
+                    </div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table
+            .getRowModel()
+            .rows.slice(0, 10)
+            .map((row) => {
+              return (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => {
+                    return (
+                      <td key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+      {pageable ? (
+        <div className="table-paging">
+          <button
+            className="table-paging-btn table-paging-prev"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<'}
+          </button>
+          {Array.from({ length: table.getPageCount() }).map((row, index) => {
             return (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => {
-                  return (
-                    <td key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </td>
-                  );
-                })}
-              </tr>
+              <button
+                key={index}
+                className={`table-paging-btn table-paging-btn ${
+                  index === paging.pageIndex ? 'table-paging-btn-active' : ''
+                }`}
+                onClick={() => table.setPageIndex(index)}
+              >
+                {index + 1}
+              </button>
             );
           })}
-      </tbody>
-    </table>
+          <button
+            className="table-paging-btn table-paging-next"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>'}
+          </button>
+        </div>
+      ) : (
+        <></>
+      )}
+    </>
   );
 };
 

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -101,10 +101,8 @@ export const DataTable = ({
               {headerGroup.headers.map((header) => (
                 <th key={header.id}>
                   <div
-                    {...{
-                      className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
-                      onClick: header.column.getToggleSortingHandler(),
-                    }}
+                    className={header.column.getCanSort() ? 'cursor-pointer select-none' : ''}
+                    onClick={header.column.getToggleSortingHandler()}
                   >
                     {flexRender(header.column.columnDef.header, header.getContext())}
                     {{

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -141,6 +141,7 @@ export const DataTable = ({
       {pageable ? (
         <div className="table-paging">
           <button
+            id="table-paging-prev-btn"
             className="table-paging-btn table-paging-prev"
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
@@ -150,7 +151,8 @@ export const DataTable = ({
           {Array.from({ length: table.getPageCount() }).map((row, index) => {
             return (
               <button
-                key={index}
+                id="table-paging-btn"
+                key={`paging-btn-${row}-${index}`}
                 className={`table-paging-btn table-paging-btn ${
                   index === paging.pageIndex ? 'table-paging-btn-active' : ''
                 }`}
@@ -161,6 +163,7 @@ export const DataTable = ({
             );
           })}
           <button
+            id="table-paging-next-btn"
             className="table-paging-btn table-paging-next"
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -1,5 +1,12 @@
-import React from 'react';
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import React, { useEffect } from 'react';
+import {
+  ColumnSort,
+  SortingState,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
 import classNames from 'classnames';
 import './data-table.style.css';
 
@@ -16,7 +23,22 @@ export interface DataTableProps<T = any> {
    * The data to display in the table rows
    */
   data: T[];
-  striped: boolean;
+  /**
+   * A boolean indicating if the table is striped or not
+   */
+  striped?: boolean;
+  /**
+   * A boolean indicating if the table is sortable or not
+   */
+  sortable?: boolean;
+  /**
+   * The column id to set as the default sort
+   */
+  sortCol?: string;
+  /**
+   * The default sort direction if sortIndex is provided
+   */
+  sortDir?: 'asc' | 'desc';
   /**
    * Additional class names for the table
    */
@@ -29,13 +51,25 @@ export const DataTable = ({
   id,
   columns,
   data,
-  striped,
+  striped = false,
+  sortable = false,
+  sortCol,
+  sortDir,
   className,
 }: DataTableProps): React.ReactElement => {
+  const [sorting, setSorting] = React.useState<SortingState>(
+    sortable ? [{ id: sortCol ?? columns[0], desc: sortDir === 'desc' }] : [],
+  );
   const table = useReactTable({
     data,
     columns,
+    state: {
+      sorting,
+    },
+    enableSorting: sortable,
+    onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
   return (
@@ -45,22 +79,42 @@ export const DataTable = ({
           <tr key={headerGroup.id}>
             {headerGroup.headers.map((header) => (
               <th key={header.id}>
-                {header.isPlaceholder
-                  ? null
-                  : flexRender(header.column.columnDef.header, header.getContext())}
+                {header.isPlaceholder ? null : (
+                  <div
+                    {...{
+                      className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                      onClick: header.column.getToggleSortingHandler(),
+                    }}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {{
+                      asc: '  ↑',
+                      desc: '  ↓',
+                    }[header.column.getIsSorted() as string] ?? null}
+                  </div>
+                )}
               </th>
             ))}
           </tr>
         ))}
       </thead>
       <tbody>
-        {table.getRowModel().rows.map((row) => (
-          <tr key={row.id}>
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-            ))}
-          </tr>
-        ))}
+        {table
+          .getRowModel()
+          .rows.slice(0, 10)
+          .map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
       </tbody>
     </table>
   );

--- a/packages/comet-extras/src/components/data-table/index.ts
+++ b/packages/comet-extras/src/components/data-table/index.ts
@@ -1,0 +1,1 @@
+export { default } from './data-table';

--- a/packages/comet-extras/src/components/index.ts
+++ b/packages/comet-extras/src/components/index.ts
@@ -1,2 +1,3 @@
+export { default as DataTable } from './data-table';
 export { default as Spinner } from './spinner';
 export { default as Tabs, TabPanel } from './tabs';


### PR DESCRIPTION
Add a more flexible and functional react data table to Comet

## Description

- Added [TanStack Table](https://tanstack.com/table/v8) package to project
- Added custom component based on TanStack table to Comet Extras, providing flexible data rendering, sorting, and paging
- Added Stories for new Data Table to Extras section
- Added Unit tests for coverage

## Related Issue

N/A

## Motivation and Context

- To provide a more customized data table for use in projects

## How Has This Been Tested?

- Local Testing
- Unit Testing
- Verified no accessibility issues

## Screenshots (if appropriate):
<img width="1036" alt="Screenshot 2023-09-05 at 11 44 52 AM" src="https://github.com/MetroStar/comet/assets/61591423/76e3b987-8a9f-4a8a-81a6-ced9840c656e">
<img width="1042" alt="Screenshot 2023-09-05 at 11 44 36 AM" src="https://github.com/MetroStar/comet/assets/61591423/8f3913f0-cda9-4164-8253-2d999a397ea7">
<img width="1039" alt="Screenshot 2023-09-05 at 3 03 01 PM" src="https://github.com/MetroStar/comet/assets/61591423/acc14ca6-72f0-4366-965c-b4a5b9405eb3">
<img width="1053" alt="Screenshot 2023-09-05 at 11 51 38 AM" src="https://github.com/MetroStar/comet/assets/61591423/8f6239fb-df32-4876-9932-1fd9fa813c0a">
