### PR TITLE
CSG-1032: Comet USWDS Components with children should allow rendering of React children or a list of items

### DIFF
--- a/packages/comet-uswds/src/components/accordion/accordion.stories.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 import { Accordion } from '../../index';
-import { AccordionProps } from './accordion';
+import { AccordionItem, AccordionProps } from './accordion';
 
 const meta: Meta<typeof Accordion> = {
   title: 'USWDS/Accordion',
@@ -18,20 +18,6 @@ export const Default = Template.bind({});
 Default.args = {
   id: 'accordion-1',
   allowMultiSelect: false,
-  items: [
-    {
-      id: 'item-1',
-      label: 'Item 1',
-      child: <span>Hello</span>,
-      expanded: true,
-    },
-    {
-      id: 'item-2',
-      label: 'Item 2',
-      child: <span>World</span>,
-      expanded: false,
-    },
-  ],
 };
 
 export const MultiSelect = Template.bind({});
@@ -42,14 +28,31 @@ MultiSelect.args = {
     {
       id: 'item-1',
       label: 'Item 1',
-      child: <span>Hello</span>,
+      children: <span>Hello</span>,
       expanded: false,
     },
     {
       id: 'item-2',
       label: 'Item 2',
-      child: <span>World</span>,
+      children: <span>World</span>,
       expanded: false,
     },
   ],
+};
+
+const ChildrenTemplate: StoryFn<typeof Accordion> = (args: AccordionProps) => (
+  <Accordion {...args}>
+    <AccordionItem id="item-1" label="Item 1" expanded={true}>
+      <span>Hello</span>
+    </AccordionItem>
+    <AccordionItem id="item-2" label="Item 2" expanded={false}>
+      <span>World</span>
+    </AccordionItem>
+  </Accordion>
+);
+
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
+  id: 'accordion-3',
+  allowMultiSelect: false,
 };

--- a/packages/comet-uswds/src/components/accordion/accordion.stories.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.stories.tsx
@@ -18,6 +18,20 @@ export const Default = Template.bind({});
 Default.args = {
   id: 'accordion-1',
   allowMultiSelect: false,
+  items: [
+    {
+      id: 'item-1',
+      label: 'Item 1',
+      children: <span>Hello</span>,
+      expanded: true,
+    },
+    {
+      id: 'item-2',
+      label: 'Item 2',
+      children: <span>World</span>,
+      expanded: false,
+    },
+  ],
 };
 
 export const MultiSelect = Template.bind({});

--- a/packages/comet-uswds/src/components/accordion/accordion.stories.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
-import { Accordion } from '../../index';
-import { AccordionItem, AccordionProps } from './accordion';
+import { Accordion, AccordionItem } from '../../index';
+import { AccordionProps } from './accordion';
 
 const meta: Meta<typeof Accordion> = {
   title: 'USWDS/Accordion',

--- a/packages/comet-uswds/src/components/accordion/accordion.test.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.test.tsx
@@ -11,7 +11,7 @@ describe('Accordion', () => {
         id: 'item-1',
         label: 'foo',
         expanded: false,
-        child: <span>bar</span>,
+        children: <span>bar</span>,
       },
     ];
     const { container } = render(<Accordion id="accordion" items={items} />);
@@ -24,7 +24,7 @@ describe('Accordion', () => {
         id: 'item-1',
         label: 'foo',
         expanded: false,
-        child: <span>bar</span>,
+        children: <span>bar</span>,
       },
     ];
     render(<Accordion id="accordion" items={items} />);
@@ -43,7 +43,7 @@ describe('Accordion', () => {
         id: 'item-1',
         label: 'foo',
         expanded: true,
-        child: <span>bar</span>,
+        children: <span>bar</span>,
       },
     ];
     render(<Accordion id="accordion" items={items} />);
@@ -62,7 +62,7 @@ describe('Accordion', () => {
         id: 'item-1',
         label: 'foo',
         expanded: false,
-        child: <span>bar</span>,
+        children: <span>bar</span>,
       },
     ];
     render(<Accordion id="accordion" items={items} allowMultiSelect={true} />);
@@ -73,5 +73,10 @@ describe('Accordion', () => {
     fireEvent.click(screen.getByTestId('accordion-button'));
 
     expect(screen.getByText('bar')).toBeVisible();
+  });
+
+  test('should not render when no items or children are provided', () => {
+    const { container } = render(<Accordion id="accordion" />);
+    expect(container.querySelector('#accordion')).toBeFalsy();
   });
 });

--- a/packages/comet-uswds/src/components/accordion/accordion.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.tsx
@@ -1,9 +1,9 @@
-import React, { ReactNode, useEffect, useRef } from 'react';
-import clasnames from 'classnames';
+import React, { ReactElement, ReactNode, useEffect, useRef } from 'react';
+import classnames from 'classnames';
 import accordion from '@uswds/uswds/js/usa-accordion';
 import './accordion.style.css';
 
-export interface AccordionItem {
+export interface AccordionItemProps {
   /**
    * The unique identifier for the accordion item
    */
@@ -19,7 +19,7 @@ export interface AccordionItem {
   /**
    * The body of the accordion item
    */
-  child: ReactNode;
+  children: ReactNode;
 }
 
 export interface AccordionProps {
@@ -34,7 +34,11 @@ export interface AccordionProps {
   /**
    * An array of AccordionItem objects, used to build the accordion
    */
-  items: AccordionItem[];
+  items?: AccordionItemProps[];
+  /**
+   * The body of the accordion
+   */
+  children?: Array<ReactElement<AccordionItemProps>>;
 }
 
 /**
@@ -44,7 +48,13 @@ export const Accordion = ({
   id,
   allowMultiSelect = false,
   items,
+  children,
 }: AccordionProps): React.ReactElement => {
+  // If no children and items provided, render partial
+  if (!children && !items) {
+    return <></>;
+  }
+
   // Ensure accordion JS is loaded
   const accordionRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -71,34 +81,53 @@ export const Accordion = ({
     <div
       id={id}
       ref={accordionRef}
-      className={clasnames('usa-accordion', {
+      className={classnames('usa-accordion', {
         'usa-accordion--multiselectable': allowMultiSelect,
       })}
       data-allow-multiple={allowMultiSelect ? true : undefined}
     >
-      {items.map((e, i) => (
-        <div className="accordion-item" data-testid="accordion-item" key={`accordion-item-${i}`}>
-          <h4 className="usa-accordion__heading">
-            <button
-              type="button"
-              className="usa-accordion__button"
-              data-testid="accordion-button"
-              aria-expanded={items[i].expanded}
-              aria-controls={items[i].id}
-            >
-              {e.label}
-            </button>
-          </h4>
-          <div
-            id={items[i].id}
-            className="usa-accordion__content usa-prose text-left"
-            data-testid="accordion-content"
-            hidden={!items[i].expanded}
+      {children ??
+        items?.map((e, i) => (
+          <AccordionItem
+            id={e.id}
+            key={`accordion-item-${i}`}
+            label={e.label}
+            expanded={e.expanded}
           >
-            {e.child}
-          </div>
-        </div>
-      ))}
+            {e.children}
+          </AccordionItem>
+        ))}
+    </div>
+  );
+};
+
+export const AccordionItem = ({
+  id,
+  label,
+  expanded,
+  children,
+}: AccordionItemProps): React.ReactElement => {
+  return (
+    <div className="accordion-item" data-testid="accordion-item">
+      <h4 className="usa-accordion__heading">
+        <button
+          type="button"
+          className="usa-accordion__button"
+          data-testid="accordion-button"
+          aria-expanded={expanded}
+          aria-controls={id}
+        >
+          {label}
+        </button>
+      </h4>
+      <div
+        id={id}
+        className="usa-accordion__content usa-prose text-left"
+        data-testid="accordion-content"
+        hidden={!expanded}
+      >
+        {children}
+      </div>
     </div>
   );
 };

--- a/packages/comet-uswds/src/components/accordion/accordion.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.tsx
@@ -38,7 +38,7 @@ export interface AccordionProps {
   /**
    * The body of the accordion
    */
-  children?: Array<ReactElement<AccordionItemProps>>;
+  children?: ReactElement<AccordionItemProps> | Array<ReactElement<AccordionItemProps>>;
 }
 
 /**
@@ -49,7 +49,7 @@ export const Accordion = ({
   allowMultiSelect = false,
   items,
   children,
-}: AccordionProps): React.ReactElement => {
+}: AccordionProps): ReactElement => {
   // If no children and items provided, render partial
   if (!children && !items) {
     return <></>;
@@ -106,7 +106,7 @@ export const AccordionItem = ({
   label,
   expanded,
   children,
-}: AccordionItemProps): React.ReactElement => {
+}: AccordionItemProps): ReactElement => {
   return (
     <div className="accordion-item" data-testid="accordion-item">
       <h4 className="usa-accordion__heading">

--- a/packages/comet-uswds/src/components/accordion/accordion.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.tsx
@@ -36,7 +36,7 @@ export interface AccordionProps {
    */
   items?: AccordionItemProps[];
   /**
-   * The body of the accordion
+   * The body of the component
    */
   children?: ReactElement<AccordionItemProps> | Array<ReactElement<AccordionItemProps>>;
 }

--- a/packages/comet-uswds/src/components/accordion/accordion.tsx
+++ b/packages/comet-uswds/src/components/accordion/accordion.tsx
@@ -36,7 +36,7 @@ export interface AccordionProps {
    */
   items?: AccordionItemProps[];
   /**
-   * The body of the component
+   * AccordionItem components to display as children
    */
   children?: ReactElement<AccordionItemProps> | Array<ReactElement<AccordionItemProps>>;
 }

--- a/packages/comet-uswds/src/components/accordion/index.ts
+++ b/packages/comet-uswds/src/components/accordion/index.ts
@@ -1,1 +1,1 @@
-export { default, AccordionItem } from './accordion';
+export { default, AccordionItem, AccordionItemProps } from './accordion';

--- a/packages/comet-uswds/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/packages/comet-uswds/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StoryFn, Meta } from '@storybook/react';
-import { Breadcrumb } from '../../index';
-import { BreadcrumbProps, Crumb } from './breadcrumb';
+import { Breadcrumb, BreadcrumbItem } from '../../index';
+import { BreadcrumbItemProps, BreadcrumbProps } from './breadcrumb';
 
 const meta: Meta<typeof Breadcrumb> = {
   title: 'USWDS/Breadcrumb',
@@ -11,10 +11,12 @@ export default meta;
 
 const Template: StoryFn<typeof Breadcrumb> = (args: BreadcrumbProps) => <Breadcrumb {...args} />;
 
+const action = (c: BreadcrumbItemProps): void => alert('Called with: ' + JSON.stringify(c));
+
 export const Default = Template.bind({});
 Default.args = {
   id: 'breadcrumb-1',
-  crumbs: [
+  items: [
     {
       name: 'Rome',
       path: '/rome',
@@ -25,5 +27,19 @@ Default.args = {
     },
   ],
   current: 'Italy',
-  action: (c: Crumb) => alert('Called with: ' + JSON.stringify(c)),
+  action,
+};
+
+const ChildrenTemplate: StoryFn<typeof Breadcrumb> = (args: BreadcrumbProps) => (
+  <Breadcrumb {...args}>
+    <BreadcrumbItem name="Rome" path="/rome" action={args.action} />
+    <BreadcrumbItem name="Greece" path="/greece" action={args.action} />
+  </Breadcrumb>
+);
+
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
+  id: 'breadcrumb-2',
+  current: 'Italy',
+  action,
 };

--- a/packages/comet-uswds/src/components/breadcrumb/breadcrumb.test.tsx
+++ b/packages/comet-uswds/src/components/breadcrumb/breadcrumb.test.tsx
@@ -2,22 +2,22 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import Breadcrumb from './breadcrumb';
+import Breadcrumb, { BreadcrumbItem } from './breadcrumb';
 
 describe('Breadcrumb', () => {
   test('should render with no accessibility violations', async () => {
     const spy = jest.fn();
     const crumbs = [{ path: '/test', name: 'test' }];
     const { container } = render(
-      <Breadcrumb id="breadcrumb" crumbs={crumbs} current="foo" action={spy} />,
+      <Breadcrumb id="breadcrumb" items={crumbs} current="foo" action={spy} />,
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
   test('should render with given props and is callable', () => {
     const spy = jest.fn();
-    const crumbs = [{ path: '/test', name: 'test' }];
-    render(<Breadcrumb id="breadcrumb" crumbs={crumbs} current="foo" action={spy} />);
+    const crumbs = [{ path: '/test', name: 'test', action: spy }];
+    render(<Breadcrumb id="breadcrumb" items={crumbs} current="foo" action={spy} />);
 
     expect(screen.getByText('test')).toBeVisible();
     expect(screen.getByText('foo')).toBeVisible();
@@ -30,6 +30,22 @@ describe('Breadcrumb', () => {
   test('should render when current is optional', () => {
     const spy = jest.fn();
     const crumbs = [{ path: '/test', name: 'test' }];
-    render(<Breadcrumb id="breadcrumb" crumbs={crumbs} action={spy} />);
+    render(<Breadcrumb id="breadcrumb" items={crumbs} action={spy} />);
+  });
+
+  test('should not render when no children or items are provided', () => {
+    const spy = jest.fn();
+    const { container } = render(<Breadcrumb id="breadcrumb" action={spy} />);
+    expect(container.querySelector('#breadcrumb')).toBeFalsy();
+  });
+
+  test('should render with children', () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <Breadcrumb id="breadcrumb" action={spy}>
+        <BreadcrumbItem path="/test" name="test" />
+      </Breadcrumb>,
+    );
+    expect(container.querySelector('#breadcrumb')).toBeTruthy();
   });
 });

--- a/packages/comet-uswds/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/comet-uswds/src/components/breadcrumb/breadcrumb.tsx
@@ -33,7 +33,7 @@ export interface BreadcrumbProps {
    */
   items?: BreadcrumbItemProps[];
   /**
-   * The body of the component
+   * BreadcrumbItem components to display as children
    */
   children?: ReactElement<BreadcrumbItemProps> | Array<ReactElement<BreadcrumbItemProps>>;
 }

--- a/packages/comet-uswds/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/comet-uswds/src/components/breadcrumb/breadcrumb.tsx
@@ -33,7 +33,7 @@ export interface BreadcrumbProps {
    */
   items?: BreadcrumbItemProps[];
   /**
-   * The body of the breadcrumb
+   * The body of the component
    */
   children?: ReactElement<BreadcrumbItemProps> | Array<ReactElement<BreadcrumbItemProps>>;
 }

--- a/packages/comet-uswds/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/comet-uswds/src/components/breadcrumb/breadcrumb.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
-export interface Crumb {
+export interface BreadcrumbItemProps {
   /**
    * The intended url path for the item
    */
@@ -9,6 +9,10 @@ export interface Crumb {
    * The display value for this bread crumb item
    */
   name: string;
+  /**
+   * Custom callback for when breadcrumb item is clicked
+   */
+  action?: Function;
 }
 
 export interface BreadcrumbProps {
@@ -17,10 +21,6 @@ export interface BreadcrumbProps {
    */
   id: string;
   /**
-   * An array of bread crumb objects to display
-   */
-  crumbs: Crumb[];
-  /**
    * Custom callback for when breadcrumb item is clicked
    */
   action: Function;
@@ -28,6 +28,14 @@ export interface BreadcrumbProps {
    * Custom value to display as the current location
    */
   current?: string;
+  /**
+   * An array of bread crumb items to display
+   */
+  items?: BreadcrumbItemProps[];
+  /**
+   * The body of the breadcrumb
+   */
+  children?: ReactElement<BreadcrumbItemProps> | Array<ReactElement<BreadcrumbItemProps>>;
 }
 
 /**
@@ -35,24 +43,23 @@ export interface BreadcrumbProps {
  */
 export const Breadcrumb = ({
   id,
-  crumbs,
   current,
   action,
-}: BreadcrumbProps): React.ReactElement => {
+  items,
+  children,
+}: BreadcrumbProps): ReactElement => {
+  // If no children and items provided, render partial
+  if (!children && !items) {
+    return <></>;
+  }
+
   return (
     <nav className="usa-breadcrumb breadcrumb" aria-label="Breadcrumbs,," id={id}>
       <ol className="usa-breadcrumb__list">
-        {crumbs.map((e, i) => (
-          <li className="usa-breadcrumb__list-item" key={`breadcrumb-${i}`}>
-            <span
-              className="usa-breadcrumb__link span-link"
-              data-testid="breadcrumb-link"
-              onClick={() => action(e.path)}
-            >
-              <span>{e.name}</span>
-            </span>
-          </li>
-        ))}
+        {children ??
+          items?.map((e, i) => (
+            <BreadcrumbItem path={e.path} name={e.name} action={action} key={`breadcrumb-${i}`} />
+          ))}
         {current ? (
           <li className="usa-breadcrumb__list-item usa-current" aria-current="true">
             <span>{current}</span>
@@ -62,6 +69,27 @@ export const Breadcrumb = ({
         )}
       </ol>
     </nav>
+  );
+};
+
+export const BreadcrumbItem = ({ path, name, action }: BreadcrumbItemProps): ReactElement => {
+  return (
+    <li className="usa-breadcrumb__list-item">
+      <span
+        className="usa-breadcrumb__link span-link"
+        data-testid="breadcrumb-link"
+        onClick={() => {
+          /* istanbul ignore else */
+          if (action) {
+            action(path);
+          } else {
+            return false;
+          }
+        }}
+      >
+        <span>{name}</span>
+      </span>
+    </li>
   );
 };
 

--- a/packages/comet-uswds/src/components/breadcrumb/index.ts
+++ b/packages/comet-uswds/src/components/breadcrumb/index.ts
@@ -1,1 +1,1 @@
-export { default, BreadcrumbItem } from './breadcrumb';
+export { default, BreadcrumbItem, BreadcrumbItemProps } from './breadcrumb';

--- a/packages/comet-uswds/src/components/breadcrumb/index.ts
+++ b/packages/comet-uswds/src/components/breadcrumb/index.ts
@@ -1,1 +1,1 @@
-export { default, Crumb } from './breadcrumb';
+export { default, BreadcrumbItem } from './breadcrumb';

--- a/packages/comet-uswds/src/components/combo-box/combo-box.stories.tsx
+++ b/packages/comet-uswds/src/components/combo-box/combo-box.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 import React, { ChangeEvent, useState } from 'react';
-import { ComboBox, ComboBoxOption, ComboBoxProps } from './combo-box';
+import { ComboBox, ComboBoxOptionProps, ComboBoxProps } from './combo-box';
 
 const meta: Meta<typeof ComboBox> = {
   title: 'USWDS/Forms/Combo Box',
@@ -15,7 +15,7 @@ const loremText =
   'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Necessitatibus explicabo magnam, harum eos repellat pariatur, quia itaque dolorum qui ipsa dolore sapiente tempore ipsum ut quibusdam esse natus, iusto mollitia.';
 const loremWords = [...loremText.replace('.', '').replace(',', '').split(' ')];
 const options = loremWords.map((word) => {
-  return { value: word.toLowerCase(), label: word } as ComboBoxOption;
+  return { value: word.toLowerCase(), label: word } as ComboBoxOptionProps;
 });
 
 const ComboBoxWrapper: React.FC<ComboBoxProps> = (props: ComboBoxProps) => {

--- a/packages/comet-uswds/src/components/combo-box/combo-box.test.tsx
+++ b/packages/comet-uswds/src/components/combo-box/combo-box.test.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import ComboBox, { ComboBoxOption } from './combo-box';
+import ComboBox, { ComboBoxOptionProps } from './combo-box';
 
 describe('ComboBox', () => {
   const defaultId = 'combo-box1';
   const defaultName = 'combo-box-name';
   const loremWords = ['Lorem', 'Ipsum', 'Dolor', 'Sit'];
   const options = loremWords.map((word) => {
-    return { value: word.toLowerCase(), label: word } as ComboBoxOption;
+    return { value: word.toLowerCase(), label: word } as ComboBoxOptionProps;
   });
 
   test('should render with no accessibility violations', async () => {

--- a/packages/comet-uswds/src/components/combo-box/combo-box.tsx
+++ b/packages/comet-uswds/src/components/combo-box/combo-box.tsx
@@ -2,7 +2,7 @@ import Select, { SelectOptionProps, SelectProps } from '../select/select';
 import comboBox from '@uswds/uswds/js/usa-combo-box';
 import React, { RefObject, useLayoutEffect, useRef } from 'react';
 
-export type ComboBoxOption = SelectOptionProps;
+export type ComboBoxOptionProps = SelectOptionProps;
 export type ComboBoxProps = {
   /**
    * The unique identifier for this component

--- a/packages/comet-uswds/src/components/combo-box/combo-box.tsx
+++ b/packages/comet-uswds/src/components/combo-box/combo-box.tsx
@@ -1,8 +1,8 @@
-import Select, { SelectOption, SelectProps } from '../select/select';
+import Select, { SelectOptionProps, SelectProps } from '../select/select';
 import comboBox from '@uswds/uswds/js/usa-combo-box';
 import React, { RefObject, useLayoutEffect, useRef } from 'react';
 
-export type ComboBoxOption = SelectOption;
+export type ComboBoxOption = SelectOptionProps;
 export type ComboBoxProps = {
   /**
    * The unique identifier for this component

--- a/packages/comet-uswds/src/components/combo-box/index.ts
+++ b/packages/comet-uswds/src/components/combo-box/index.ts
@@ -1,1 +1,1 @@
-export { default, ComboBoxOption } from './combo-box';
+export { default, ComboBoxOptionProps } from './combo-box';

--- a/packages/comet-uswds/src/components/error-messages/error-messages.stories.tsx
+++ b/packages/comet-uswds/src/components/error-messages/error-messages.stories.tsx
@@ -23,3 +23,16 @@ MultipleErrors.args = {
   id: 'errors-2',
   errors: ['This is an error.', 'This is another error.'],
 };
+
+const ChildrenTemplate: StoryFn<typeof ErrorMessages> = (args: ErrorMessagesProps) => (
+  <ErrorMessages {...args}>
+    <span className="usa-error-message">Error 1</span>
+    <span className="usa-error-message">Error 2</span>
+    <span className="usa-error-message">Error 3</span>
+  </ErrorMessages>
+);
+
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
+  id: 'errors-3',
+};

--- a/packages/comet-uswds/src/components/error-messages/error-messages.test.tsx
+++ b/packages/comet-uswds/src/components/error-messages/error-messages.test.tsx
@@ -29,4 +29,9 @@ describe('ErrorMessage', () => {
     const errorMessages = baseElement.querySelectorAll('.usa-error-message');
     expect(errorMessages).toHaveLength(2);
   });
+
+  test('should not render when no items or children are provided', () => {
+    const { container } = render(<ErrorMessages id="errors" />);
+    expect(container.querySelector('#errors')).toBeFalsy();
+  });
 });

--- a/packages/comet-uswds/src/components/error-messages/error-messages.tsx
+++ b/packages/comet-uswds/src/components/error-messages/error-messages.tsx
@@ -10,7 +10,7 @@ export interface ErrorMessagesProps {
    */
   errors?: string[];
   /**
-   * The body of the component
+   * ReactNode components to display as children
    */
   children?: ReactNode;
 }

--- a/packages/comet-uswds/src/components/error-messages/error-messages.tsx
+++ b/packages/comet-uswds/src/components/error-messages/error-messages.tsx
@@ -23,6 +23,7 @@ export const ErrorMessages = ({
   errors,
   children,
 }: ErrorMessagesProps): React.ReactElement => {
+  // If no children and items provided, render partial
   if (!children && !errors) {
     return <></>;
   }

--- a/packages/comet-uswds/src/components/error-messages/error-messages.tsx
+++ b/packages/comet-uswds/src/components/error-messages/error-messages.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 export interface ErrorMessagesProps {
   /**
@@ -8,7 +8,11 @@ export interface ErrorMessagesProps {
   /**
    * An array of error strings to display
    */
-  errors: string[];
+  errors?: string[];
+  /**
+   * The body of the component
+   */
+  children?: ReactNode;
 }
 
 /**
@@ -17,16 +21,22 @@ export interface ErrorMessagesProps {
 export const ErrorMessages = ({
   id = undefined,
   errors,
+  children,
 }: ErrorMessagesProps): React.ReactElement => {
+  if (!children && !errors) {
+    return <></>;
+  }
+
   return (
     <>
-      {errors.map((error, index) => {
-        return (
-          <span id={`${id}-${index}`} key={index} className="usa-error-message">
-            {error}
-          </span>
-        );
-      })}
+      {children ??
+        errors?.map((error, index) => {
+          return (
+            <span id={`${id}-${index}`} key={index} className="usa-error-message">
+              {error}
+            </span>
+          );
+        })}
     </>
   );
 };

--- a/packages/comet-uswds/src/components/error-messages/index.ts
+++ b/packages/comet-uswds/src/components/error-messages/index.ts
@@ -1,1 +1,1 @@
-export { default } from './error-messages';
+export { default, ErrorMessagesProps } from './error-messages';

--- a/packages/comet-uswds/src/components/index.ts
+++ b/packages/comet-uswds/src/components/index.ts
@@ -1,7 +1,7 @@
 export { default as Accordion, AccordionItem } from './accordion';
 export { default as Alert } from './alert';
 export { default as Banner } from './banner';
-export { default as Breadcrumb, Crumb } from './breadcrumb';
+export { default as Breadcrumb, BreadcrumbItem } from './breadcrumb';
 export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';
 export { default as Card, CardFooter, CardBody, CardHeader } from './card';

--- a/packages/comet-uswds/src/components/index.ts
+++ b/packages/comet-uswds/src/components/index.ts
@@ -1,7 +1,7 @@
-export { default as Accordion, AccordionItem } from './accordion';
+export { default as Accordion, AccordionItem, AccordionItemProps } from './accordion';
 export { default as Alert } from './alert';
 export { default as Banner } from './banner';
-export { default as Breadcrumb, BreadcrumbItem } from './breadcrumb';
+export { default as Breadcrumb, BreadcrumbItem, BreadcrumbItemProps } from './breadcrumb';
 export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';
 export { default as Card, CardFooter, CardBody, CardHeader } from './card';
@@ -23,13 +23,17 @@ export { default as List, ListItem } from './list';
 export { default as MemorableDate } from './memorable-date';
 export { default as Modal } from './modal';
 export { default as Pagination, CreatePageUrlHandler, OnPageHandler } from './pagination';
-export { default as ProcessList, ProcessListStep } from './process-list';
+export { default as ProcessList, ProcessListStep, ProcessListStepProps } from './process-list';
 export { default as Prose } from './prose';
 export { default as RadioButton, RadioButtonGroup, RadioButtonData } from './radio-button';
 export { default as RangeSlider } from './range-slider';
 export { default as Search } from './search';
-export { default as Select, SelectOption } from './select';
-export { default as SideNavigation, SideNavigationItem } from './side-navigation';
+export { default as Select, SelectOption, SelectOptionProps } from './select';
+export {
+  default as SideNavigation,
+  SideNavigationItem,
+  SideNavigationItemProps,
+} from './side-navigation';
 export { default as SiteAlert } from './site-alert';
 export { default as StepIndicator } from './step-indicator';
 export { default as SummaryBox } from './summary-box';

--- a/packages/comet-uswds/src/components/index.ts
+++ b/packages/comet-uswds/src/components/index.ts
@@ -7,7 +7,7 @@ export { default as ButtonGroup } from './button-group';
 export { default as Card, CardFooter, CardBody, CardHeader } from './card';
 export { default as CharacterCount, CharacterCountContainer } from './character-count';
 export { default as Checkbox, CheckboxGroup, CheckboxData } from './checkbox';
-export { default as ComboBox, ComboBoxOption } from './combo-box';
+export { default as ComboBox, ComboBoxOptionProps } from './combo-box';
 export { default as DatePicker } from './date-picker';
 export { default as DateRangePicker } from './date-range-picker';
 export { default as ErrorMessages } from './error-messages';

--- a/packages/comet-uswds/src/components/process-list/index.ts
+++ b/packages/comet-uswds/src/components/process-list/index.ts
@@ -1,1 +1,1 @@
-export { default, ProcessListStep } from './process-list';
+export { default, ProcessListStep, ProcessListStepProps } from './process-list';

--- a/packages/comet-uswds/src/components/process-list/process-list.stories.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.stories.tsx
@@ -4,7 +4,7 @@ import {
   ProcessList,
   ProcessListProps,
   ProcessListStep,
-  ProcessListStepProp,
+  ProcessListStepProps,
 } from './process-list';
 
 const meta: Meta<typeof ProcessList> = {
@@ -18,7 +18,7 @@ export default meta;
 
 const Template: StoryFn<typeof ProcessList> = (args: ProcessListProps) => <ProcessList {...args} />;
 
-const steps: ProcessListStepProp[] = [
+const steps: ProcessListStepProps[] = [
   {
     heading: 'Start a process',
     children: (

--- a/packages/comet-uswds/src/components/process-list/process-list.stories.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.stories.tsx
@@ -1,6 +1,11 @@
-import React, { ReactHTMLElement } from 'react';
+import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
-import { ProcessList, ProcessListProps, ProcessListStep } from './process-list';
+import {
+  ProcessList,
+  ProcessListProps,
+  ProcessListStep,
+  ProcessListStepProp,
+} from './process-list';
 
 const meta: Meta<typeof ProcessList> = {
   title: 'USWDS/Process List',
@@ -13,10 +18,10 @@ export default meta;
 
 const Template: StoryFn<typeof ProcessList> = (args: ProcessListProps) => <ProcessList {...args} />;
 
-const steps: ProcessListStep[] = [
+const steps: ProcessListStepProp[] = [
   {
     heading: 'Start a process',
-    content: (
+    children: (
       <p>
         Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
         gravida, orci magna rhoncus neque.
@@ -25,7 +30,7 @@ const steps: ProcessListStep[] = [
   },
   {
     heading: 'Start a process',
-    content: (
+    children: (
       <p>
         Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
         gravida, orci magna rhoncus neque.
@@ -34,7 +39,7 @@ const steps: ProcessListStep[] = [
   },
   {
     heading: 'Proceed to the second step',
-    content: (
+    children: (
       <p>
         Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
         gravida, orci magna rhoncus neque, id pulvinar odio lorem non turpis. Nullam sit amet enim.
@@ -45,7 +50,7 @@ const steps: ProcessListStep[] = [
   },
   {
     heading: 'Complete the step-by-step process',
-    content: (
+    children: (
       <p>
         Nullam sit amet enim. Suspendisse id velit vitae ligula volutpat condimentum. Aliquam erat
         volutpat. Sed quis velit. Nulla facilisi. Nulla libero. Vivamus pharetra posuere sapien.
@@ -61,7 +66,7 @@ Default.args = {
 };
 
 const noContentSteps = steps.map((step) => {
-  return { heading: step.heading, content: null };
+  return { heading: step.heading, children: null };
 });
 
 export const NoStepContent = Template.bind({});
@@ -70,19 +75,50 @@ NoStepContent.args = {
   steps: noContentSteps,
 };
 
-const customSizingSteps = steps.map((step) => {
-  return {
-    heading: step.heading,
-    content: React.cloneElement(step.content as ReactHTMLElement<HTMLElement>, {
-      className: 'font-sans-lg margin-top-1 text-light',
-    }),
-  };
-});
+const ChildrenTemplate: StoryFn<typeof ProcessList> = (args: ProcessListProps) => (
+  <ProcessList {...args}>
+    <ProcessListStep heading="Step 1">
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
+      gravida, orci magna rhoncus neque.
+    </ProcessListStep>
+    <ProcessListStep heading="Step 2">
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
+      gravida, orci magna rhoncus neque.
+    </ProcessListStep>
+    <ProcessListStep heading="Step 3">
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
+      gravida, orci magna rhoncus neque.
+    </ProcessListStep>
+  </ProcessList>
+);
 
-export const CustomSizing = Template.bind({});
-CustomSizing.args = {
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
   id: 'process-list-3',
-  steps: customSizingSteps,
-  headingElementName: 'p',
-  headingClassName: 'font-sans-xl line-height-sans-1',
+};
+
+const CustomSizingTemplate: StoryFn<typeof ProcessList> = (args: ProcessListProps) => (
+  <ProcessList {...args}>
+    <ProcessListStep
+      heading="Step 1"
+      headingElementName="h5"
+      headingClassName="font-sans-lg margin-top-1 text-light"
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
+      gravida, orci magna rhoncus neque.
+    </ProcessListStep>
+    <ProcessListStep
+      heading="Step 2"
+      headingElementName="h5"
+      headingClassName="font-sans-lg margin-top-1 text-light"
+    >
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra
+      gravida, orci magna rhoncus neque.
+    </ProcessListStep>
+  </ProcessList>
+);
+
+export const CustomSizing = CustomSizingTemplate.bind({});
+CustomSizing.args = {
+  id: 'process-list-4',
 };

--- a/packages/comet-uswds/src/components/process-list/process-list.test.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.test.tsx
@@ -8,7 +8,7 @@ describe('Process list', () => {
   const steps: ProcessListStep[] = [
     {
       heading: 'Start a process',
-      content: (
+      children: (
         <p>
           Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed
           pharetra gravida, orci magna rhoncus neque.
@@ -17,7 +17,7 @@ describe('Process list', () => {
     },
     {
       heading: 'Start a process',
-      content: (
+      children: (
         <p>
           Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed
           pharetra gravida, orci magna rhoncus neque.
@@ -26,7 +26,7 @@ describe('Process list', () => {
     },
     {
       heading: 'Proceed to the second step',
-      content: (
+      children: (
         <p>
           Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed
           pharetra gravida, orci magna rhoncus neque, id pulvinar odio lorem non turpis. Nullam sit
@@ -37,7 +37,7 @@ describe('Process list', () => {
     },
     {
       heading: 'Complete the step-by-step process',
-      content: (
+      children: (
         <p>
           Nullam sit amet enim. Suspendisse id velit vitae ligula volutpat condimentum. Aliquam erat
           volutpat. Sed quis velit. Nulla facilisi. Nulla libero. Vivamus pharetra posuere sapien.
@@ -67,12 +67,15 @@ describe('Process list', () => {
 
   test('should render a process list with different heading elements', () => {
     const { baseElement } = render(
-      <ProcessList
-        id={defaultId}
-        steps={steps}
-        headingElementName="p"
-        headingClassName="font-sans-xl line-height-sans-1"
-      />,
+      <ProcessList id={defaultId}>
+        <ProcessListStep
+          heading="Step 1"
+          headingElementName="p"
+          headingClassName="font-sans-xl line-height-sans-1"
+        >
+          Step 1 Content
+        </ProcessListStep>
+      </ProcessList>,
     );
     expect(baseElement).toBeTruthy();
     const processListNodes = baseElement.querySelectorAll('.usa-process-list__heading');
@@ -81,5 +84,10 @@ describe('Process list', () => {
       expect(processListNode?.classList).toContain('font-sans-xl');
       expect(processListNode?.classList).toContain('line-height-sans-1');
     });
+  });
+
+  test('should not render when no items or children are provided', () => {
+    const { container } = render(<ProcessList id="process-list" />);
+    expect(container.querySelector('#process-list')).toBeFalsy();
   });
 });

--- a/packages/comet-uswds/src/components/process-list/process-list.test.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import ProcessList, { ProcessListStep } from './process-list';
+import ProcessList, { ProcessListStep, ProcessListStepProps } from './process-list';
 
 describe('Process list', () => {
   const defaultId = 'process-list1';
-  const steps: ProcessListStep[] = [
+  const steps: ProcessListStepProps[] = [
     {
       heading: 'Start a process',
       children: (

--- a/packages/comet-uswds/src/components/process-list/process-list.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.tsx
@@ -15,7 +15,7 @@ export interface ProcessListStepProp {
    */
   headingClassName?: string;
   /**
-   * The body of the accordion item
+   * The body of the step
    */
   children: ReactNode;
 }

--- a/packages/comet-uswds/src/components/process-list/process-list.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 import classnames from 'classnames';
 
-export interface ProcessListStepProp {
+export interface ProcessListStepProps {
   /**
    * The heading for the step
    */
@@ -28,11 +28,11 @@ export interface ProcessListProps {
   /**
    * The level of the headings
    */
-  steps?: ProcessListStepProp[];
+  steps?: ProcessListStepProps[];
   /**
    * ProcessListStep components to display as children
    */
-  children?: ReactElement<ProcessListStepProp> | Array<ReactElement<ProcessListStepProp>>;
+  children?: ReactElement<ProcessListStepProps> | Array<ReactElement<ProcessListStepProps>>;
 }
 
 /**
@@ -60,7 +60,7 @@ export const ProcessListStep = ({
   headingClassName,
   headingElementName = 'h4',
   children,
-}: ProcessListStepProp): ReactElement => {
+}: ProcessListStepProps): ReactElement => {
   const headingClasses = classnames('usa-process-list__heading', headingClassName);
   return (
     <li className="usa-process-list__item">

--- a/packages/comet-uswds/src/components/process-list/process-list.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import classnames from 'classnames';
 
-export interface ProcessListProps {
+export interface ProcessListStepProp {
   /**
-   * The unique identifier for this component
+   * The heading for the step
    */
-  id: string;
+  heading: string;
   /**
    * The level of the headings
    */
@@ -15,50 +15,64 @@ export interface ProcessListProps {
    */
   headingClassName?: string;
   /**
-   * The level of the headings
+   * The body of the accordion item
    */
-  steps: ProcessListStep[];
+  children: ReactNode;
 }
 
-export interface ProcessListStep {
+export interface ProcessListProps {
   /**
-   * The heading for the step
+   * The unique identifier for this component
    */
-  heading: string;
+  id: string;
   /**
-   * The content of the step
+   * The level of the headings
    */
-  content: ReactNode;
+  steps?: ProcessListStepProp[];
+  /**
+   * The body of the component
+   */
+  children?: ReactElement<ProcessListStepProp> | Array<ReactElement<ProcessListStepProp>>;
 }
 
 /**
  * A process list displays the steps or stages of important instructions or processes.
  */
-export const ProcessList = ({
-  id,
-  headingElementName = 'h4',
-  headingClassName,
-  steps,
-}: ProcessListProps): React.ReactElement => {
+export const ProcessList = ({ id, steps, children }: ProcessListProps): ReactElement => {
+  if (!children && !steps) {
+    return <></>;
+  }
+
   return (
     <ol id={id} className="usa-process-list">
-      {steps.map((step, stepIndex) => {
-        const headingClasses = classnames('usa-process-list__heading', headingClassName);
-
-        return (
-          <li key={stepIndex} className="usa-process-list__item">
-            {React.createElement(
-              headingElementName,
-              {
-                className: headingClasses,
-              },
-              step.heading,
-            )}
-            {step.content}
-          </li>
-        );
-      })}
+      {children ??
+        steps?.map((step, stepIndex) => (
+          <ProcessListStep heading={step.heading} key={stepIndex}>
+            {step.children}
+          </ProcessListStep>
+        ))}
     </ol>
+  );
+};
+
+export const ProcessListStep = ({
+  heading,
+  headingClassName,
+  headingElementName = 'h4',
+  children,
+}: ProcessListStepProp): ReactElement => {
+  const headingClasses = classnames('usa-process-list__heading', headingClassName);
+  return (
+    <li className="usa-process-list__item">
+      {React.createElement(
+        headingElementName,
+        {
+          className: headingClasses,
+        },
+        heading,
+      )}
+      {children}
+    </li>
   );
 };
 

--- a/packages/comet-uswds/src/components/process-list/process-list.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.tsx
@@ -30,7 +30,7 @@ export interface ProcessListProps {
    */
   steps?: ProcessListStepProp[];
   /**
-   * The body of the component
+   * ProcessListStep components to display as children
    */
   children?: ReactElement<ProcessListStepProp> | Array<ReactElement<ProcessListStepProp>>;
 }

--- a/packages/comet-uswds/src/components/process-list/process-list.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.tsx
@@ -39,6 +39,7 @@ export interface ProcessListProps {
  * A process list displays the steps or stages of important instructions or processes.
  */
 export const ProcessList = ({ id, steps, children }: ProcessListProps): ReactElement => {
+  // If no children and items provided, render partial
   if (!children && !steps) {
     return <></>;
   }

--- a/packages/comet-uswds/src/components/select/index.ts
+++ b/packages/comet-uswds/src/components/select/index.ts
@@ -1,1 +1,1 @@
-export { default, SelectOption } from './select';
+export { default, SelectOption, SelectOptionProps } from './select';

--- a/packages/comet-uswds/src/components/select/select.stories.tsx
+++ b/packages/comet-uswds/src/components/select/select.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import React, { ChangeEvent, useState } from 'react';
 import Label from '../label/label';
-import { Select, SelectOption, SelectProps } from './select';
+import { Select, SelectOption, SelectOptionProps, SelectProps } from './select';
 
 const meta: Meta<typeof Select> = {
   title: 'USWDS/Forms/Select',
@@ -15,7 +15,7 @@ export default meta;
 
 const loremWords = ['Lorem', 'Ipsum', 'Dolor', 'Sit'];
 const options = loremWords.map((word) => {
-  return { value: word.toLowerCase(), label: word } as SelectOption;
+  return { value: word.toLowerCase(), label: word } as SelectOptionProps;
 });
 
 const SelectWrapper: React.FC<SelectProps> = (props: SelectProps) => {
@@ -37,4 +37,18 @@ Standard.args = {
   id: 'select-1',
   name: 'select-1',
   options,
+};
+
+const ChildrenTemplate: StoryFn<typeof Select> = (args: SelectProps) => (
+  <Select {...args}>
+    <SelectOption value="1" label="Item 1" />
+    <SelectOption value="2" label="Item 2" />
+    <SelectOption value="3" label="Item 3" />
+  </Select>
+);
+
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
+  id: 'select-2',
+  name: 'select-2',
 };

--- a/packages/comet-uswds/src/components/select/select.test.tsx
+++ b/packages/comet-uswds/src/components/select/select.test.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import Select, { SelectOption } from './select';
+import Select, { SelectOption, SelectOptionProps } from './select';
 
 describe('Select', () => {
   const defaultId = 'select-1';
   const defaultName = 'select-name';
   const loremWords = ['Lorem', 'Ipsum', 'Dolor', 'Sit'];
   const options = loremWords.map((word) => {
-    return { value: word.toLowerCase(), label: word } as SelectOption;
+    return { value: word.toLowerCase(), label: word } as SelectOptionProps;
   });
 
   test('should render with no accessibility violations', async () => {
@@ -70,5 +70,21 @@ describe('Select', () => {
     expect(onChange).toHaveBeenCalledTimes(0);
     await userEvent.selectOptions(selectElement, options[0].value as string);
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('should render a select with children successfully', () => {
+    const { baseElement } = render(
+      <Select id={defaultId} name={defaultName}>
+        <SelectOption value="1" label="Item 1" />
+        <SelectOption value="2" label="Item 2" />
+        <SelectOption value="3" label="Item 3" />
+      </Select>,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  test('should not render when no items or children are provided', () => {
+    const { container } = render(<Select id="select" />);
+    expect(container.querySelector('#select')).toBeFalsy();
   });
 });

--- a/packages/comet-uswds/src/components/select/select.tsx
+++ b/packages/comet-uswds/src/components/select/select.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
-import React, { ChangeEventHandler } from 'react';
+import React, { ChangeEventHandler, ReactElement } from 'react';
 
-export interface SelectOption {
+export interface SelectOptionProps {
   /**
    * The value for the option
    */
@@ -24,11 +24,15 @@ export interface SelectProps {
   /**
    * The default option of the select
    */
-  defaultOption?: SelectOption | null;
+  defaultOption?: SelectOptionProps | null;
   /**
    * The options of the select
    */
-  options?: SelectOption[];
+  options?: SelectOptionProps[];
+  /**
+   * The body of the component
+   */
+  children?: ReactElement<SelectOptionProps> | Array<ReactElement<SelectOptionProps>>;
   /**
    * Event handler for when value of the select is changed
    */
@@ -43,18 +47,27 @@ export const Select = ({
   options,
   onChange,
   className,
+  children,
   ...selectProps
-}: SelectProps & JSX.IntrinsicElements['select']): React.ReactElement => {
+}: SelectProps & JSX.IntrinsicElements['select']): ReactElement => {
+  if (!children && !options) {
+    return <></>;
+  }
+
   return (
     <select className={classNames('usa-select', className)} onChange={onChange} {...selectProps}>
       {createOption(defaultOption, -1)}
-      {options?.map(createOption)}
+      {children ?? options?.map(createOption)}
     </select>
   );
 };
 
+export const SelectOption = ({ value, label }: SelectOptionProps): ReactElement => {
+  return <option value={value}>{label}</option>;
+};
+
 const createOption = (
-  option: SelectOption | null,
+  option: SelectOptionProps | null,
   optionIndex: number,
 ): React.ReactElement | null =>
   option && (

--- a/packages/comet-uswds/src/components/select/select.tsx
+++ b/packages/comet-uswds/src/components/select/select.tsx
@@ -30,7 +30,7 @@ export interface SelectProps {
    */
   options?: SelectOptionProps[];
   /**
-   * The body of the component
+   * SelectOption components to display as children
    */
   children?: ReactElement<SelectOptionProps> | Array<ReactElement<SelectOptionProps>>;
   /**

--- a/packages/comet-uswds/src/components/select/select.tsx
+++ b/packages/comet-uswds/src/components/select/select.tsx
@@ -50,6 +50,7 @@ export const Select = ({
   children,
   ...selectProps
 }: SelectProps & JSX.IntrinsicElements['select']): ReactElement => {
+  // If no children and items provided, render partial
   if (!children && !options) {
     return <></>;
   }

--- a/packages/comet-uswds/src/components/side-navigation/index.ts
+++ b/packages/comet-uswds/src/components/side-navigation/index.ts
@@ -1,1 +1,1 @@
-export { default, SideNavigationItem } from './side-navigation';
+export { default, SideNavigationItem, SideNavigationItemProps } from './side-navigation';

--- a/packages/comet-uswds/src/components/side-navigation/side-navigation.stories.tsx
+++ b/packages/comet-uswds/src/components/side-navigation/side-navigation.stories.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
-import SideNavigation, { SideNavigationItem, SideNavigationProps } from './side-navigation';
+import SideNavigation, {
+  SideNavigationItem,
+  SideNavigationItemProps,
+  SideNavigationProps,
+} from './side-navigation';
 
 const meta: Meta<typeof SideNavigation> = {
   title: 'USWDS/Side Navigation',
@@ -21,7 +25,7 @@ const createAnchor = (isCurrent = false): JSX.Element => (
     Navigation Link
   </a>
 );
-const flatNavigation: SideNavigationItem[] = [
+const flatNavigation: SideNavigationItemProps[] = [
   {
     anchor: createAnchor(true),
   },
@@ -39,7 +43,7 @@ FlatSideNavigation.args = {
   ariaLabel,
 };
 
-const twoLevelNavigation: SideNavigationItem[] = [
+const twoLevelNavigation: SideNavigationItemProps[] = [
   {
     anchor: createAnchor(true),
     items: [
@@ -72,7 +76,7 @@ TwoLevelSideNavigation.args = {
   ariaLabel,
 };
 
-const threeLevelNavigation: SideNavigationItem[] = [
+const threeLevelNavigation: SideNavigationItemProps[] = [
   {
     anchor: createAnchor(true),
     items: [
@@ -123,4 +127,17 @@ ThreeLevelSideNavigation.args = {
   id: 'side-navigation-3',
   items: threeLevelNavigation,
   ariaLabel,
+};
+
+const ChildrenTemplate: StoryFn<typeof SideNavigation> = (args: SideNavigationProps) => (
+  <SideNavigation {...args}>
+    <SideNavigationItem anchor={createAnchor(true)} />
+    <SideNavigationItem anchor={createAnchor(false)} />
+    <SideNavigationItem anchor={createAnchor(false)} />
+  </SideNavigation>
+);
+
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
+  id: 'side-navigation-4',
 };

--- a/packages/comet-uswds/src/components/side-navigation/side-navigation.test.tsx
+++ b/packages/comet-uswds/src/components/side-navigation/side-navigation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import SideNavigation, { SideNavigationItem, SideNavigationItemProps } from './side-navigation';
+import SideNavigation, { SideNavigationItemProps } from './side-navigation';
 
 describe('SideNavigation', () => {
   const defaultId = 'side-navigation1';

--- a/packages/comet-uswds/src/components/side-navigation/side-navigation.test.tsx
+++ b/packages/comet-uswds/src/components/side-navigation/side-navigation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import SideNavigation, { SideNavigationItem } from './side-navigation';
+import SideNavigation, { SideNavigationItem, SideNavigationItemProps } from './side-navigation';
 
 describe('SideNavigation', () => {
   const defaultId = 'side-navigation1';
@@ -13,7 +13,7 @@ describe('SideNavigation', () => {
   );
 
   test('should render with no accessibility violations', async () => {
-    const flatNavigation: SideNavigationItem[] = [
+    const flatNavigation: SideNavigationItemProps[] = [
       {
         anchor: createAnchor(true),
       },
@@ -31,7 +31,7 @@ describe('SideNavigation', () => {
   });
 
   test('should render a flat side navigation successfully', () => {
-    const flatNavigation: SideNavigationItem[] = [
+    const flatNavigation: SideNavigationItemProps[] = [
       {
         anchor: createAnchor(true),
       },
@@ -49,7 +49,7 @@ describe('SideNavigation', () => {
   });
 
   test('should render a two level side navigation successfully', () => {
-    const twoLevelNavigation: SideNavigationItem[] = [
+    const twoLevelNavigation: SideNavigationItemProps[] = [
       {
         anchor: createAnchor(true),
         items: [
@@ -82,7 +82,7 @@ describe('SideNavigation', () => {
   });
 
   test('should render a three level side navigation successfully', () => {
-    const threeLevelNavigation: SideNavigationItem[] = [
+    const threeLevelNavigation: SideNavigationItemProps[] = [
       {
         anchor: createAnchor(true),
         items: [
@@ -132,5 +132,10 @@ describe('SideNavigation', () => {
       <SideNavigation id={defaultId} ariaLabel={ariaLabel} items={threeLevelNavigation} />,
     );
     expect(baseElement).toBeTruthy();
+  });
+
+  test('should not render when no items or children are provided', () => {
+    const { container } = render(<SideNavigation id="side-navigation" ariaLabel={ariaLabel} />);
+    expect(container.querySelector('#side-navigation')).toBeFalsy();
   });
 });

--- a/packages/comet-uswds/src/components/side-navigation/side-navigation.tsx
+++ b/packages/comet-uswds/src/components/side-navigation/side-navigation.tsx
@@ -39,6 +39,7 @@ export const SideNavigation = ({
   items,
   children,
 }: SideNavigationProps): ReactElement => {
+  // If no children and items provided, render partial
   if (!children && !items) {
     return <></>;
   }

--- a/packages/comet-uswds/src/components/side-navigation/side-navigation.tsx
+++ b/packages/comet-uswds/src/components/side-navigation/side-navigation.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
-export interface SideNavigationItem {
+export interface SideNavigationItemProps {
   /**
    * Anchor to render for current SideNavigationItem
    */
@@ -8,7 +8,7 @@ export interface SideNavigationItem {
   /**
    * Items of the navigation
    */
-  items?: SideNavigationItem[];
+  items?: SideNavigationItemProps[];
 }
 
 export interface SideNavigationProps {
@@ -23,7 +23,11 @@ export interface SideNavigationProps {
   /**
    * Items of the navigation
    */
-  items: SideNavigationItem[];
+  items?: SideNavigationItemProps[];
+  /**
+   * The body of the component
+   */
+  children?: ReactElement<SideNavigationItemProps> | Array<ReactElement<SideNavigationItemProps>>;
 }
 
 /**
@@ -33,23 +37,45 @@ export const SideNavigation = ({
   id,
   ariaLabel,
   items,
-}: SideNavigationProps): React.ReactElement => {
+  children,
+}: SideNavigationProps): ReactElement => {
+  if (!children && !items) {
+    return <></>;
+  }
+
   return (
     <nav id={id} aria-label={ariaLabel}>
-      <ul className="usa-sidenav">{items.map(createSideNavigationItem)}</ul>
+      <ul className="usa-sidenav">
+        {children ??
+          items?.map((item, index) => (
+            <SideNavigationItem
+              items={item.items}
+              anchor={item.anchor}
+              key={`side-nav-item-${index}`}
+            ></SideNavigationItem>
+          ))}
+      </ul>
     </nav>
   );
 };
 
-function createSideNavigationItem(item: SideNavigationItem, itemIndex: number): JSX.Element {
+export const SideNavigationItem = ({ items, anchor }: SideNavigationItemProps): JSX.Element => {
   return (
-    <li className="usa-sidenav__item" key={itemIndex}>
-      {item.anchor}
-      {item.items && item.items.length > 0 && (
-        <ul className="usa-sidenav__sublist">{item.items.map(createSideNavigationItem)}</ul>
+    <li className="usa-sidenav__item">
+      {anchor}
+      {items && items.length > 0 && (
+        <ul className="usa-sidenav__sublist">
+          {items.map((item, index) => (
+            <SideNavigationItem
+              items={item.items}
+              anchor={item.anchor}
+              key={`side-nav-item-sublist-${index}`}
+            ></SideNavigationItem>
+          ))}
+        </ul>
       )}
     </li>
   );
-}
+};
 
 export default SideNavigation;

--- a/packages/comet-uswds/src/components/side-navigation/side-navigation.tsx
+++ b/packages/comet-uswds/src/components/side-navigation/side-navigation.tsx
@@ -25,7 +25,7 @@ export interface SideNavigationProps {
    */
   items?: SideNavigationItemProps[];
   /**
-   * The body of the component
+   * SideNavigationItem components to display as children
    */
   children?: ReactElement<SideNavigationItemProps> | Array<ReactElement<SideNavigationItemProps>>;
 }


### PR DESCRIPTION
Update all applicable components with children to allow providing child content as either a dynamic list or as declarative child components.

## Description

- Updated Accordion, Breadcrumb, ErrorMessages, ProcessList, Side Navigation, Select for dynamic and declarative children
- Updated unit tests and stories to provide both item and child examples
- Updated exports

## Related Issue

https://github.com/MetroStar/comet/issues/78

## Motivation and Context

- Provide flexibility when using components with children

## How Has This Been Tested?

- Verified local unit testing and storybook testing

## Screenshots (if appropriate):
N/A