### PR TITLE
Fix Comet Extras CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21531,7 +21531,7 @@
     },
     "packages/comet-extras": {
       "name": "@metrostar/comet-extras",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-table": "8.15.3",

--- a/packages/comet-extras/package.json
+++ b/packages/comet-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-extras",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A set of custom components, intended to fill in the gaps where USWDS does not provide an implementation.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/packages/comet-extras/src/components/toggle/toggle.style.css
+++ b/packages/comet-extras/src/components/toggle/toggle.style.css
@@ -1,4 +1,3 @@
-/* Path: packages/comet-extras/src/components/toggle/toggle.tsx */
 .toggle {
   align-items: center;
   display: flex;
@@ -15,35 +14,41 @@
 .toggle-body.toggle-body-on {
   background-color: #005ea2;
 }
+
 .toggle .pos-rel {
   position: relative;
 }
+
 .toggle-dot {
   background-color: #ffffff;
   border: 1px solid #e6e6e6;
   border-radius: 9999px;
-  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  box-shadow:
+    0 1px 3px 0 rgb(0 0 0 / 0.1),
+    0 1px 2px -1px rgb(0 0 0 / 0.1);
   position: absolute;
   height: 1.5rem;
   left: 0;
   top: 0;
   width: 1.5rem;
+}
 
-  &.ml-6 {
-    margin-left: 1.5rem;
-  }
-  &.ml-0 {
-    margin-left: 0;
-  }
+.toggle-dot.ml-6 {
+  margin-left: 1.5rem;
+}
+
+.toggle-dot.ml-0 {
+  margin-left: 0;
 }
 
 .toggle-label {
   align-items: center;
   cursor: pointer;
   display: flex;
-  &.ml-3 {
-    margin-left: 0.75rem;
-  }
+}
+
+.toggle-label.ml-3 {
+  margin-left: 0.75rem;
 }
 
 .toggle-sr-only {


### PR DESCRIPTION
This is to resolve a css styling issue which is causing validation errors when running unit tests.

## Description

- Replaced nested toggle css with more specific selectors
- Updated comet-extras to next patch version

## Related Issue

N/A

## Motivation and Context

- Fix jest log errors

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1064" alt="Screenshot 2024-04-10 at 9 25 23 AM" src="https://github.com/MetroStar/comet/assets/61591423/1a8386ae-159f-4086-8c5d-2edf78fa7956">
<img width="1058" alt="Screenshot 2024-04-10 at 9 25 28 AM" src="https://github.com/MetroStar/comet/assets/61591423/ab9ac9c2-0303-4f17-9430-92179985fa23">