### PR TITLE
Add Alert Body Prop

### DIFF
--- a/packages/comet-uswds/src/components/alert/alert.stories.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.stories.tsx
@@ -26,3 +26,18 @@ Default.args = {
   noIcon: false,
   heading: '',
 };
+
+const BodyTemplate: StoryFn<typeof Alert> = (args: AlertProps) => (
+  <Alert {...args}>This is the alert body</Alert>
+);
+
+export const WithBody = BodyTemplate.bind({});
+WithBody.args = {
+  id: 'alert-1',
+  type: 'info',
+  slim: false,
+  show: true,
+  noIcon: false,
+  heading: '',
+  body: <span>This is the alert body as a prop</span>,
+};

--- a/packages/comet-uswds/src/components/alert/alert.test.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.test.tsx
@@ -43,6 +43,13 @@ describe('Alert', () => {
     expect(container.querySelector('.usa-alert__heading')).toBeTruthy();
   });
 
+  test('should render an alert with body', () => {
+    const { container } = render(
+      <Alert id="alert" type="info" heading="some heading" body="Some body" />,
+    );
+    expect(container.querySelector('.usa-alert__body')).toBeTruthy();
+  });
+
   test('should not render an alert', () => {
     const { container } = render(<Alert id="alert" type="info" show={false} />);
     expect(container.querySelector('#alert')).toBeFalsy();

--- a/packages/comet-uswds/src/components/alert/alert.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.tsx
@@ -27,6 +27,10 @@ export interface AlertProps {
    */
   heading?: string;
   /**
+   * The body of the alert as an optional prop
+   */
+  body?: React.ReactNode;
+  /**
    * The body of the alert
    */
   children?: React.ReactNode;
@@ -42,6 +46,7 @@ export const Alert = ({
   slim,
   noIcon,
   heading,
+  body,
   children,
 }: AlertProps): React.ReactElement => {
   const classes = classnames('usa-alert', {
@@ -59,7 +64,7 @@ export const Alert = ({
     <div id={id} className={classes}>
       <div className="usa-alert__body">
         {heading && <h4 className="usa-alert__heading">{heading}</h4>}
-        <p className="usa-alert__text">{children}</p>
+        {body ?? <p className="usa-alert__text">{children}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
Add new body prop to alert component, to support both existing simple text based body as well as alert components containing more advanced alert content.

## Description

- Added body prop to alert to support more advanced alert body scenarios
- Added new stories and unit tests

## Related Issue

N/A

## Motivation and Context

- The basic alert makes use of a paragraph to display alert text. Embedding anything but text within the body results in an invalid HTML combination, resulting in a console error. This addition provides a mechanism for both existing and new body alert scenarios.

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1427" alt="Screenshot 2024-05-04 at 8 12 51 PM" src="https://github.com/MetroStar/comet/assets/61591423/e72aa6a8-00d7-4896-a2fa-1c78afece3dd">