### PR TITLE
Add Current Step Support to Process List

### DIFF
--- a/packages/comet-uswds/src/components/process-list/process-list.css
+++ b/packages/comet-uswds/src/components/process-list/process-list.css
@@ -1,0 +1,27 @@
+.current.usa-process-list__item::before {
+  border: 0.25rem solid #005ea2;
+  background-color: #005ea2;
+  color: #fff;
+}
+
+.current.usa-process-list__item {
+  border-left: 0.5rem solid #005ea2;
+}
+
+.current.usa-process-list__heading {
+  color: #005ea2;
+}
+
+.completed.usa-process-list__item::before {
+  border: 0.25rem solid #162e51;
+  background-color: #162e51;
+  color: #fff;
+}
+
+.completed.usa-process-list__item:not(.last) {
+  border-left: 0.5rem solid #162e51;
+}
+
+.completed.usa-process-list__heading {
+  color: #162e51;
+}

--- a/packages/comet-uswds/src/components/process-list/process-list.stories.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.stories.tsx
@@ -65,6 +65,13 @@ Default.args = {
   steps,
 };
 
+export const CurrentStep = Template.bind({});
+CurrentStep.args = {
+  id: 'process-list-1b',
+  steps,
+  currentStep: 2,
+};
+
 const noContentSteps = steps.map((step) => {
   return { heading: step.heading, children: null };
 });

--- a/packages/comet-uswds/src/components/process-list/process-list.test.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.test.tsx
@@ -56,6 +56,11 @@ describe('Process list', () => {
     expect(baseElement).toBeTruthy();
   });
 
+  test('should render a with current step', () => {
+    const { baseElement } = render(<ProcessList id={defaultId} steps={steps} currentStep={1} />);
+    expect(baseElement).toBeTruthy();
+  });
+
   test('should render a process list with h4 heading elements', () => {
     const { baseElement } = render(<ProcessList id={defaultId} steps={steps} />);
     expect(baseElement).toBeTruthy();

--- a/packages/comet-uswds/src/components/process-list/process-list.tsx
+++ b/packages/comet-uswds/src/components/process-list/process-list.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import classnames from 'classnames';
+import './process-list.css';
 
 export interface ProcessListStepProps {
   /**
@@ -10,6 +11,18 @@ export interface ProcessListStepProps {
    * The level of the headings
    */
   headingElementName?: string;
+  /**
+   * Whether the step is the current step
+   */
+  isCurrentStep?: boolean;
+  /**
+   * Whether the step is a completed step
+   */
+  isCompletedStep?: boolean;
+  /**
+   * Whether the step is the last step
+   */
+  isLastStep?: boolean;
   /**
    * Additional class names for the heading element
    */
@@ -30,6 +43,10 @@ export interface ProcessListProps {
    */
   steps?: ProcessListStepProps[];
   /**
+   * The current step (1 based index)
+   */
+  currentStep?: number;
+  /**
    * ProcessListStep components to display as children
    */
   children?: ReactElement<ProcessListStepProps> | Array<ReactElement<ProcessListStepProps>>;
@@ -38,7 +55,12 @@ export interface ProcessListProps {
 /**
  * A process list displays the steps or stages of important instructions or processes.
  */
-export const ProcessList = ({ id, steps, children }: ProcessListProps): ReactElement => {
+export const ProcessList = ({
+  id,
+  steps,
+  currentStep = 0,
+  children,
+}: ProcessListProps): ReactElement => {
   // If no children and items provided, render partial
   if (!children && !steps) {
     return <></>;
@@ -48,7 +70,13 @@ export const ProcessList = ({ id, steps, children }: ProcessListProps): ReactEle
     <ol id={id} className="usa-process-list">
       {children ??
         steps?.map((step, stepIndex) => (
-          <ProcessListStep heading={step.heading} key={stepIndex}>
+          <ProcessListStep
+            heading={step.heading}
+            key={stepIndex}
+            isCurrentStep={currentStep === stepIndex + 1 && currentStep !== steps.length}
+            isCompletedStep={currentStep > stepIndex + 1 || currentStep === steps.length}
+            isLastStep={stepIndex === steps.length - 1}
+          >
             {step.children}
           </ProcessListStep>
         ))}
@@ -60,11 +88,28 @@ export const ProcessListStep = ({
   heading,
   headingClassName,
   headingElementName = 'h4',
+  isCurrentStep,
+  isCompletedStep,
+  isLastStep,
   children,
 }: ProcessListStepProps): ReactElement => {
-  const headingClasses = classnames('usa-process-list__heading', headingClassName);
+  const listItemClasses = classnames('usa-process-list__item', {
+    current: isCurrentStep && !isCompletedStep,
+    completed: isCompletedStep,
+    last: isLastStep,
+  });
+
+  const headingClasses = classnames(
+    'usa-process-list__heading',
+    {
+      current: isCurrentStep && !isCompletedStep,
+      completed: isCompletedStep,
+      last: isLastStep,
+    },
+    headingClassName,
+  );
   return (
-    <li className="usa-process-list__item">
+    <li className={listItemClasses}>
       {React.createElement(
         headingElementName,
         {


### PR DESCRIPTION
The current process list component does not allow indicating which step is current and/or completed. This update adds a currentStep prop to the component, which is then used to style the process list items based on the current step.

## Description

- Updated to allow setting current step on process list component
- Added new story fro current step
- Added new unit test

## Related Issue

N/A

## Motivation and Context

- Make the component more useful

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1717" alt="Screenshot 2024-05-15 at 7 25 06 AM" src="https://github.com/MetroStar/comet/assets/61591423/202f9663-01ed-406b-9a1a-e3e2c6116456">