### PR TITLE
Datatable Paging Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16543,7 +16543,7 @@
     },
     "packages/comet-extras": {
       "name": "@metrostar/comet-extras",
-      "version": "1.3.5",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-table": "8.19.2",

--- a/packages/comet-extras/package.json
+++ b/packages/comet-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-extras",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "A set of custom components, intended to fill in the gaps where USWDS does not provide an implementation.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/packages/comet-extras/src/components/data-table/data-table.tsx
+++ b/packages/comet-extras/src/components/data-table/data-table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   SortingState,
   flexRender,
@@ -109,6 +109,10 @@ export const DataTable = ({
       }
     }
   };
+
+  useEffect(() => {
+    setPaging({ pageIndex, pageSize });
+  }, [pageIndex, pageSize]);
 
   return (
     <>


### PR DESCRIPTION
Currently if the datatable page size or index is dynamically updated, the table does not rerender as expected. This update ensures the datatable paging provider is called when these values change.

## Description

- Update comet extras datatable to ensure paging is updated when pageSize and pageIndex changes

## Related Issue

N/A

## Motivation and Context

N/A

## How Has This Been Tested?

- Local Storybook Testing
- Published Beta package and tested in Comet Starter

## Screenshots (if appropriate):
N/A