### PR TITLE
Add emergency type to alert component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16347,7 +16347,7 @@
     },
     "packages/comet-uswds": {
       "name": "@metrostar/comet-uswds",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@uswds/uswds": "3.8.1",

--- a/packages/comet-uswds/package.json
+++ b/packages/comet-uswds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-uswds",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "React with TypeScript Component Library based on USWDS 3.0.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/packages/comet-uswds/src/components/alert/alert.test.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.test.tsx
@@ -28,6 +28,11 @@ describe('Alert', () => {
     expect(container.querySelector('#alert')).toHaveClass('usa-alert--success');
   });
 
+  test('should render an emergency alert', () => {
+    const { container } = render(<Alert id="alert" type="emergency" />);
+    expect(container.querySelector('#alert')).toHaveClass('usa-alert--emergency');
+  });
+
   test('should render a slim alert', () => {
     const { container } = render(<Alert id="alert" type="info" slim={true} />);
     expect(container.querySelector('#alert')).toHaveClass('usa-alert--slim');

--- a/packages/comet-uswds/src/components/alert/alert.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.tsx
@@ -9,7 +9,7 @@ export interface AlertProps {
   /**
    * The type of alert to display
    */
-  type: 'info' | 'warning' | 'error' | 'success';
+  type: 'info' | 'warning' | 'error' | 'success' | 'emergency';
   /**
    * Whether or not to display the alert
    */
@@ -53,6 +53,7 @@ export const Alert = ({
     'usa-alert--success': type === 'success',
     'usa-alert--warning': type === 'warning',
     'usa-alert--error': type === 'error',
+    'usa-alert--emergency': type === 'emergency',
     'usa-alert--info': type === 'info',
     'usa-alert--slim': slim,
     'usa-alert--no-icon': noIcon,


### PR DESCRIPTION
The current alert component does not include all USWDS alert types. Adding missing emergency alert type.

## Description

- Added emergency type to alert component
- Added unit test for coverage

## Related Issue

N/A

## Motivation and Context

- Inline with USWDS

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1066" alt="Screenshot 2024-07-17 at 1 23 22 PM" src="https://github.com/user-attachments/assets/7021d364-4d94-4521-b0c1-05d5c667e9f3">
