### PR TITLE
USWDS Table Default Sorting Rendering Inverse

### DIFF
--- a/packages/comet-uswds/src/components/table/table.tsx
+++ b/packages/comet-uswds/src/components/table/table.tsx
@@ -88,6 +88,16 @@ export const Table = ({
 }: TableProps): React.ReactElement => {
   // Ensure table JS is loaded
   const tableRef = useRef<HTMLDivElement>(null);
+
+  // Swap sort direction due underlying USWDS on function rewriting the aria-sort attribute
+  const getSortDirection = () => {
+    if (sortDir === 'descending') {
+      return 'ascending';
+    } else {
+      return 'descending';
+    }
+  };
+
   useEffect(() => {
     const tableElement = tableRef.current;
     // If sortable, call table.on to enable functionality
@@ -153,7 +163,9 @@ export const Table = ({
                   scope="col"
                   role="columnheader"
                   aria-sort={
-                    sortable && column.sortable && sortIndex === index ? sortDir : undefined
+                    sortable && column.sortable && sortIndex === index
+                      ? getSortDirection()
+                      : undefined
                   }
                 >
                   {column.name}


### PR DESCRIPTION
Currently the USWDS table renders data in the reverse order of `sortDir` prop provided. After reviewing, it appears that the initial aria-sort value is being overwrote when the USWDS `table.on()` function is being called. In order to fix the issue, this updates resets the value back.

## Description

- Updated to swap sortDir value provided to aria-sort

## Related Issue

Fixes #229 

## Motivation and Context

- Bug fix

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1066" alt="Screenshot 2024-08-12 at 11 00 25 AM" src="https://github.com/user-attachments/assets/7bbae010-e06b-4ceb-847a-4ce1fea9513e">