### PR TITLE
Remove Hardcoded Form Max Width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14392,7 +14392,7 @@
     },
     "packages/comet-uswds": {
       "name": "@metrostar/comet-uswds",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@uswds/uswds": "3.8.2",

--- a/packages/comet-uswds/package.json
+++ b/packages/comet-uswds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-uswds",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React with TypeScript Component Library based on USWDS 3.0.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/packages/comet-uswds/src/components/form/form.stories.tsx
+++ b/packages/comet-uswds/src/components/form/form.stories.tsx
@@ -77,7 +77,7 @@ const FormWrapper: React.FC = () => {
   };
 
   return (
-    <Form id="contact-form" onSubmit={handleSubmit} className="width-tablet">
+    <Form id="contact-form" onSubmit={handleSubmit} className="maxw-mobile-lg">
       <TextInput
         id="name"
         name="name"

--- a/packages/comet-uswds/src/components/form/form.tsx
+++ b/packages/comet-uswds/src/components/form/form.tsx
@@ -25,7 +25,6 @@ export const Form = ({
     <form
       id={id}
       className={classNames('usa-form', { 'usa-form--large': isLarge }, className)}
-      style={{ maxWidth: 'unset' }}
       {...formProps}
     >
       {children}


### PR DESCRIPTION
Update to ensure forms can be made more responsive.

## Description

- Removed hardcoded max width on form component
- Updated Contact Form example with USWDS mobile max width class

## Related Issue

N/A

## Motivation and Context

- Adhere to USWDS defaults
- More easily configurable

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1712" alt="Screenshot 2024-08-22 at 4 30 56 PM" src="https://github.com/user-attachments/assets/4f7f5455-08f0-4bf2-a37a-59d4c03f89b5">
<img width="486" alt="Screenshot 2024-08-22 at 4 31 10 PM" src="https://github.com/user-attachments/assets/9716423d-ec0d-47a0-b36f-24a5907ecbb0">