### PR TITLE
Fix Stories with Wrapper Components

### DIFF
--- a/packages/comet-uswds/src/components/form/form.stories.tsx
+++ b/packages/comet-uswds/src/components/form/form.stories.tsx
@@ -33,7 +33,7 @@ export const Standard = Template.bind({
   isLarge: false,
 });
 
-const FormWrapper: React.FC = () => {
+const ContactFormTemplate: StoryFn<typeof Form> = () => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
@@ -183,6 +183,4 @@ const FormWrapper: React.FC = () => {
   );
 };
 
-const WrapperTemplate: StoryFn<typeof FormWrapper> = () => <FormWrapper />;
-
-export const ContactForm = WrapperTemplate.bind({});
+export const ContactForm = ContactFormTemplate.bind({});

--- a/packages/comet-uswds/src/components/pagination/pagination.stories.tsx
+++ b/packages/comet-uswds/src/components/pagination/pagination.stories.tsx
@@ -19,19 +19,15 @@ const onPage =
     setPage(page);
   };
 
-const PaginationWrapper: React.FC<PaginationProps> = (props: PaginationProps) => {
-  const [currentPage1, setCurrentPage1] = useState(props.currentPage);
+const Template: StoryFn<typeof Pagination> = (args: PaginationProps) => {
+  const [currentPage1, setCurrentPage1] = useState(args.currentPage);
 
-  const newProps = { ...props };
+  const newProps = { ...args };
   newProps.currentPage = currentPage1;
   newProps.onPage = onPage(setCurrentPage1);
 
   return <Pagination {...newProps} />;
 };
-
-const Template: StoryFn<typeof Pagination> = (args: PaginationProps) => (
-  <PaginationWrapper {...args} />
-);
 
 export const LargePagination = Template.bind({});
 LargePagination.args = {

--- a/packages/comet-uswds/src/components/step-indicator/step-indicator.stories.tsx
+++ b/packages/comet-uswds/src/components/step-indicator/step-indicator.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState, Dispatch, SetStateAction } from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 import { StepIndicator, StepIndicatorProps } from './step-indicator';
 import Button from '../button/button';
+import ButtonGroup from '../button-group';
 
 const meta: Meta<typeof StepIndicator> = {
   title: 'USWDS/Step Indicator',
@@ -16,14 +17,14 @@ export default meta;
 
 const steps: string[] = ['Lorem', 'Ipsum', 'Dolor', 'Sit', 'Amet'];
 
-const StepIndicatorWrapper: React.FC<StepIndicatorProps> = (props: StepIndicatorProps) => {
-  const [currentStep, setCurrentStep] = useState(props.currentStep);
-  function prevNextButtons([currentStep, setCurrentStep]: [
+const Template: StoryFn<typeof StepIndicator> = (args: StepIndicatorProps) => {
+  const [currentStep, setCurrentStep] = useState(args.currentStep);
+  const prevNextButtons = ([currentStep, setCurrentStep]: [
     number,
     Dispatch<SetStateAction<number>>,
-  ]): JSX.Element {
+  ]) => {
     return (
-      <>
+      <ButtonGroup>
         <Button
           id="previous-button"
           disabled={currentStep <= 0}
@@ -38,11 +39,11 @@ const StepIndicatorWrapper: React.FC<StepIndicatorProps> = (props: StepIndicator
         >
           Next
         </Button>
-      </>
+      </ButtonGroup>
     );
-  }
+  };
 
-  const newProps = { ...props };
+  const newProps = { ...args };
   newProps.currentStep = currentStep;
 
   return (
@@ -52,10 +53,6 @@ const StepIndicatorWrapper: React.FC<StepIndicatorProps> = (props: StepIndicator
     </>
   );
 };
-
-const Template: StoryFn<typeof StepIndicator> = (args: StepIndicatorProps) => (
-  <StepIndicatorWrapper {...args} />
-);
 
 export const Standard = Template.bind({});
 Standard.args = {


### PR DESCRIPTION
## Description

- Removed wrappers from stories to allow storybook to display full code example.
- Misc cleanup

## Related Issue

N/A

## Motivation and Context

- Better Code Examples

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):

### Before
<img width="1044" alt="Screenshot 2024-08-23 at 8 57 22 AM" src="https://github.com/user-attachments/assets/4db4a5bf-5072-4587-b4e8-8192b3c78031">

### After
<img width="1039" alt="Screenshot 2024-08-23 at 8 57 46 AM" src="https://github.com/user-attachments/assets/2376400c-c24e-44f6-a7cd-477c57be8c5c">
