### PR TITLE
Big Button Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14395,7 +14395,7 @@
     },
     "packages/comet-uswds": {
       "name": "@metrostar/comet-uswds",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@uswds/uswds": "3.8.2",

--- a/packages/comet-uswds/package.json
+++ b/packages/comet-uswds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-uswds",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "React with TypeScript Component Library based on USWDS 3.0.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",

--- a/packages/comet-uswds/src/components/button/button.stories.tsx
+++ b/packages/comet-uswds/src/components/button/button.stories.tsx
@@ -10,6 +10,7 @@ const meta: Meta<typeof Button> = {
     id: { required: true },
     type: { control: 'select', required: true },
     variant: { control: 'select' },
+    size: { control: 'select' },
     disabled: { control: 'boolean' },
   },
 };
@@ -22,6 +23,7 @@ Default.args = {
   id: 'button-1',
   type: 'button',
   variant: 'default',
+  size: 'default',
   className: '',
   disabled: false,
 };

--- a/packages/comet-uswds/src/components/button/button.test.tsx
+++ b/packages/comet-uswds/src/components/button/button.test.tsx
@@ -43,14 +43,14 @@ describe('Button', () => {
     expect(screen.getByTestId('button')).toHaveClass('usa-button--inverse');
   });
 
-  test('should render a big button', () => {
-    render(<Button id="button" variant="big"></Button>);
-    expect(screen.getByTestId('button')).toHaveClass('usa-button--big');
-  });
-
   test('should render a unstyled button', () => {
     render(<Button id="button" variant="unstyled"></Button>);
     expect(screen.getByTestId('button')).toHaveClass('usa-button--unstyled');
+  });
+
+  test('should render a big button', () => {
+    render(<Button id="button" size="big"></Button>);
+    expect(screen.getByTestId('button')).toHaveClass('usa-button--big');
   });
 
   test('should render a button with custom className', () => {

--- a/packages/comet-uswds/src/components/button/button.tsx
+++ b/packages/comet-uswds/src/components/button/button.tsx
@@ -23,7 +23,7 @@ export interface ButtonProps {
     | 'outline-inverse'
     | 'unstyled';
   /**
-   * The size of the tag
+   * The size of the button
    */
   size?: 'default' | 'big';
   /**

--- a/packages/comet-uswds/src/components/button/button.tsx
+++ b/packages/comet-uswds/src/components/button/button.tsx
@@ -21,8 +21,11 @@ export interface ButtonProps {
     | 'base'
     | 'outline'
     | 'outline-inverse'
-    | 'big'
     | 'unstyled';
+  /**
+   * The size of the tag
+   */
+  size?: 'default' | 'big';
   /**
    * A custom class to apply to the component
    */
@@ -44,6 +47,7 @@ export const Button = ({
   id,
   type = 'button',
   variant = 'default',
+  size = 'default',
   className,
   children,
   ...props
@@ -57,8 +61,8 @@ export const Button = ({
       'usa-button--base': variant === 'base',
       'usa-button--outline': variant === 'outline',
       'usa-button--outline usa-button--inverse': variant === 'outline-inverse',
-      'usa-button--big': variant === 'big',
       'usa-button--unstyled': variant === 'unstyled',
+      'usa-button--big': size === 'big',
     },
     className,
   );


### PR DESCRIPTION
Currently the Big version of the USWDS button is provided as a variant, preventing the button from being rendered as big and some other color variant. This update adds size as a new prop, allowing any variant to be used with any size.

## Description

- Updated button to provide Big variant through size prop
- Updated unit tests and stories to reflect the change
- Updated comet-uswds to next minor version

## Related Issue

N/A

## Motivation and Context

- Provide additional button variations

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1080" alt="Screenshot 2024-08-26 at 3 21 42 PM" src="https://github.com/user-attachments/assets/adc51b4a-f356-41a6-9fee-6c992604698e">
<img width="1075" alt="Screenshot 2024-08-26 at 3 21 50 PM" src="https://github.com/user-attachments/assets/7e04235d-5642-4697-aac2-5e22a5cecefb">
