### PR TITLE
Add Close Action to the USWDS Alert

### DIFF
--- a/packages/comet-uswds/src/components/alert/alert.stories.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.stories.tsx
@@ -24,7 +24,24 @@ Default.args = {
   slim: false,
   show: true,
   noIcon: false,
+  allowClose: false,
   heading: '',
+};
+
+export const AllowClose = Template.bind({});
+AllowClose.args = {
+  id: 'alert-close',
+  type: 'info',
+  slim: false,
+  show: true,
+  noIcon: false,
+  allowClose: true,
+  heading: 'Alert with close button',
+  body: <span>This is the alert body as a prop</span>,
+  onClose: () => {
+    // eslint-disable-next-line no-console
+    console.log('Alert closed');
+  },
 };
 
 const BodyTemplate: StoryFn<typeof Alert> = (args: AlertProps) => (
@@ -38,6 +55,7 @@ WithBody.args = {
   slim: false,
   show: true,
   noIcon: false,
+  allowClose: false,
   heading: '',
   body: <span>This is the alert body as a prop</span>,
 };

--- a/packages/comet-uswds/src/components/alert/alert.stories.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.stories.tsx
@@ -37,7 +37,6 @@ AllowClose.args = {
   noIcon: false,
   allowClose: true,
   heading: 'Alert with close button',
-  body: <span>This is the alert body as a prop</span>,
   onClose: () => {
     // eslint-disable-next-line no-console
     console.log('Alert closed');

--- a/packages/comet-uswds/src/components/alert/alert.style.css
+++ b/packages/comet-uswds/src/components/alert/alert.style.css
@@ -1,0 +1,4 @@
+.usa-alert__body {
+  max-width: unset !important;
+  padding-right: 1rem !important;
+}

--- a/packages/comet-uswds/src/components/alert/alert.test.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import Alert from './alert';
 
@@ -46,6 +46,27 @@ describe('Alert', () => {
   test('should render an alert with heading', () => {
     const { container } = render(<Alert id="alert" type="info" heading="some heading" />);
     expect(container.querySelector('.usa-alert__heading')).toBeTruthy();
+  });
+
+  test('should render a closable alert', () => {
+    const { container } = render(<Alert id="alert" type="info" allowClose={true} />);
+    const button = container.querySelector('.usa-button');
+    expect(button).toBeTruthy();
+    expect(button).toHaveAttribute('aria-label', 'Close');
+  });
+
+  test('should allow closing an alert', async () => {
+    const spy = vi.fn();
+    const { container } = render(<Alert id="alert" type="info" allowClose={true} onClose={spy} />);
+    const button = container.querySelector('.usa-button');
+    expect(button).toBeTruthy();
+    if (button) {
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(container.querySelector('#alert')).toBeFalsy();
+      expect(spy).toHaveBeenCalled();
+    }
   });
 
   test('should render an alert with body', () => {

--- a/packages/comet-uswds/src/components/alert/alert.tsx
+++ b/packages/comet-uswds/src/components/alert/alert.tsx
@@ -1,4 +1,8 @@
 import classnames from 'classnames';
+import Button from '../button';
+import Icon from '../icon';
+import { useState } from 'react';
+import './alert.style.css';
 
 export interface AlertProps {
   /**
@@ -22,6 +26,10 @@ export interface AlertProps {
    */
   noIcon?: boolean;
   /**
+   * Whether or not to display the close button
+   */
+  allowClose?: boolean;
+  /**
    * Whether or not to display the alert heading
    */
   heading?: string;
@@ -33,6 +41,10 @@ export interface AlertProps {
    * The body of the alert
    */
   children?: React.ReactNode;
+  /**
+   * The function to call when the alert is closed
+   * */
+  onClose?: () => void;
 }
 
 /**
@@ -44,10 +56,13 @@ export const Alert = ({
   show = true,
   slim,
   noIcon,
+  allowClose = false,
   heading,
   body,
   children,
+  onClose,
 }: AlertProps): React.ReactElement => {
+  const [closed, setClosed] = useState(!show);
   const classes = classnames('usa-alert', {
     'usa-alert--success': type === 'success',
     'usa-alert--warning': type === 'warning',
@@ -58,12 +73,35 @@ export const Alert = ({
     'usa-alert--no-icon': noIcon,
   });
 
-  if (!show) return <></>;
+  if (closed) return <></>;
 
   return (
     <div id={id} className={classes}>
       <div className="usa-alert__body">
-        {heading && <h4 className="usa-alert__heading">{heading}</h4>}
+        <div className="display-flex">
+          <div className="flex-1">
+            {heading && <h4 className="usa-alert__heading">{heading}</h4>}
+          </div>
+          <div className="flex-0">
+            {allowClose && (
+              <Button
+                id={`close-btn-${id}`}
+                variant="unstyled"
+                aria-label="Close"
+                onClick={() => {
+                  setClosed(true);
+                  if (onClose) {
+                    onClose();
+                  }
+                }}
+              >
+                <div className="margin-auto">
+                  <Icon id={`close-btn-icon-${id}`} type="close" />
+                </div>
+              </Button>
+            )}
+          </div>
+        </div>
         {body ?? <p className="usa-alert__text">{children}</p>}
       </div>
     </div>


### PR DESCRIPTION
While the USWDS alert doesn't provide a specification for closing an alert, it is a common use to allow closing the alert by clicking a close action on the alert. This update adds new props to support that use case.

## Description

- Added new allowClose and onClose props to support closing alerts
- Updated alert component to display close button when allowClose is true
- Updated alert component to run onClose callback when provided and alert is closed
- Updated alert styling to ensure body width is not restricted (this ensure the close action is properly right justified)
- Added new Allow Close story
- Added and updated unit tests

## Related Issue

N/A

## Motivation and Context

- Support common use case of closing an alert

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1058" alt="Screenshot 2024-09-27 at 12 21 32 PM" src="https://github.com/user-attachments/assets/e3fc34f3-5fce-487b-8974-a5455890a35d">
