### PR TITLE
Remove React Dependencies from Packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12138,11 +12138,9 @@
     },
     "packages/comet-data-viz": {
       "name": "@metrostar/comet-data-viz",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
         "victory": "^37.3.4"
       },
       "peerDependencies": {
@@ -12152,12 +12150,10 @@
     },
     "packages/comet-extras": {
       "name": "@metrostar/comet-extras",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tanstack/react-table": "8.20.6",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "@tanstack/react-table": "8.20.6"
       },
       "peerDependencies": {
         "@tanstack/react-table": "8.20.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12163,13 +12163,11 @@
     },
     "packages/comet-uswds": {
       "name": "@metrostar/comet-uswds",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@uswds/uswds": "3.11.0",
-        "classnames": "^2.5.1",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "classnames": "^2.5.1"
       },
       "peerDependencies": {
         "@uswds/uswds": "3.11.0",

--- a/packages/comet-data-viz/package.json
+++ b/packages/comet-data-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-data-viz",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A set of Victory Chart components provided as a Comet wrapper",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
@@ -21,8 +21,6 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
     "victory": "^37.3.4"
   },
   "peerDependencies": {

--- a/packages/comet-extras/package.json
+++ b/packages/comet-extras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-extras",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A set of custom components, intended to fill in the gaps where USWDS does not provide an implementation.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
@@ -17,9 +17,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/react-table": "8.20.6",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@tanstack/react-table": "8.20.6"
   },
   "peerDependencies": {
     "@tanstack/react-table": "8.20.6",

--- a/packages/comet-uswds/package.json
+++ b/packages/comet-uswds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrostar/comet-uswds",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "React with TypeScript Component Library based on USWDS 3.0.",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
@@ -19,9 +19,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@uswds/uswds": "3.11.0",
-    "classnames": "^2.5.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "classnames": "^2.5.1"
   },
   "peerDependencies": {
     "@uswds/uswds": "3.11.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removed react dependencies from react-based packages for peer deps in order to better support multiple versions of react.
- Updated packages to next patch version

## Related Issue

N/A

## Motivation and Context

- Explict react version dependencies was leading to conflicting react versions when used in react 18 app

## How Has This Been Tested?

- Local Testing
- Deployed beta testing

## Screenshots (if appropriate):
N/A