### PR TITLE
Allow Manual Publish

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -3,6 +3,17 @@ name: Publish Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to publish'
+        required: true
+        type: choice
+        options:
+          - comet-uswds
+          - comet-extras
+          - comet-data-viz
+          - comet-cli
 
 jobs:
   build-and-publish:
@@ -23,10 +34,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Determine Package to Build
+        id: set-package
+        run: |
+          PACKAGE="${{ github.event.inputs.package || 'comet-uswds' }}"
+          echo "package=$PACKAGE" >> $GITHUB_OUTPUT
+          echo "build_command=build:$PACKAGE" >> $GITHUB_OUTPUT
+
       - name: Build Package
-        run: npm run build:comet-uswds
+        run: npm run ${{ steps.set-package.outputs.build_command }}
 
       - name: Publish Package
-        run: cd packages/comet-uswds && npm publish --access public --provenance
+        run: |
+          cd packages/${{ steps.set-package.outputs.package }}
+          npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,8 +20,10 @@ Note: currently full releases are tied to the main `comet-uswds` package.
 1. Create a new release branch in the form of `comet-data-viz-release-[MAJOR.MINOR.PATCH]`
 2. Create a PR into main (should only include package.json and package-lock.json)
 3. Once approved, merge the PR into main
-4. Open a terminal on your local machine and navigate to the root of the project
-5. Run a build for the specific package (example below):
+4. Navigate to the Actions GitHub page and click Publish Package from the left
+5. Click the Run workflow dropdown, select the package to publish, and click Run workflow
+6. Verify the Publish Package GitHub Action completes correctly
+7. Verify a new release is available in NPM
 
 ```
 npm run build:comet-data-viz


### PR DESCRIPTION
The current publish package workflow only supports publishing the primary comet-uswds package from GitHub to NPM, based on release. This update allows running manually with a user defined input for the package to publish. This does not affect the current automated comet-uswds release-based publishing.

## Description

- Updated publish package workflow to allow manual run, to publish package based on input
- Updated readme

## Related Issue

N/A

## Motivation and Context

- Automate publish of all packages

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):
