### PR TITLE
Fix Comet Toggle Styling

### DIFF
--- a/packages/comet-extras/src/components/toggle/toggle.style.css
+++ b/packages/comet-extras/src/components/toggle/toggle.style.css
@@ -6,7 +6,7 @@
 .toggle-body {
   background-color: #e6e6e6;
   border-radius: 9999px;
-  box-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+  /*box-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);*/
   height: 1.5rem;
   width: 3rem;
 }
@@ -21,16 +21,16 @@
 
 .toggle-dot {
   background-color: #ffffff;
-  border: 1px solid #e6e6e6;
   border-radius: 9999px;
-  box-shadow:
+  /*box-shadow:
     0 1px 3px 0 rgb(0 0 0 / 0.1),
-    0 1px 2px -1px rgb(0 0 0 / 0.1);
+    0 1px 2px -1px rgb(0 0 0 / 0.1);*/
   position: absolute;
-  height: 1.5rem;
-  left: 0;
-  top: 0;
-  width: 1.5rem;
+  height: 1.25rem;
+  left: 0.125rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.25rem;
 }
 
 .toggle-dot.ml-6 {

--- a/packages/comet-extras/src/components/toggle/toggle.style.css
+++ b/packages/comet-extras/src/components/toggle/toggle.style.css
@@ -6,7 +6,6 @@
 .toggle-body {
   background-color: #e6e6e6;
   border-radius: 9999px;
-  /*box-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);*/
   height: 1.5rem;
   width: 3rem;
 }
@@ -22,9 +21,6 @@
 .toggle-dot {
   background-color: #ffffff;
   border-radius: 9999px;
-  /*box-shadow:
-    0 1px 3px 0 rgb(0 0 0 / 0.1),
-    0 1px 2px -1px rgb(0 0 0 / 0.1);*/
   position: absolute;
   height: 1.25rem;
   left: 0.125rem;


### PR DESCRIPTION
## Description

Removed box shadow, circle border/shadow, and decreased circle size for toggle switch. Also adjusted left margin for toggle dot.

## Related Issue

https://metrostarsys.sharepoint.com/sites/FrontendDevCoP/Lists/Tasks/DispForm.aspx?ID=47&e=eQhrhh

## Motivation and Context

The toggle button was not centered properly, was fixed by shifting and resizing the toggle button.
https://metrostarsys.sharepoint.com/sites/FrontendDevCoP/Lists/Tasks/DispForm.aspx?ID=47&e=eQhrhh

## How Has This Been Tested?

Locally ran cloned repo for Comet in browser, before editing toggle.style.css to see live changes in browser. These changes are localized to just the toggle button and any parts of Comet that use it.

## Screenshots (if appropriate):
Before:
<img width="340" alt="Screenshot 2025-06-04 at 3 39 36 PM" src="https://github.com/user-attachments/assets/44b2fff2-c6ed-4437-9cfb-b431159a5456" />
After:
![image](https://github.com/user-attachments/assets/7c53c0f0-bc85-41d3-8abf-cfbb9fc18fc7)

